### PR TITLE
Remove duplicate `math-verify` in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,8 +40,6 @@ if stale_egg_info.exists():
 # IMPORTANT: all dependencies should be listed here with their version requirements, if any.
 #   * If a dependency is fast-moving (e.g. transformers), pin to the exact version
 _deps = [
-    "latex2sympy2_extended>=0.9.3",
-    "math_verify>=0.3.3",
     "accelerate>=1.2.1",
     "bitsandbytes>=0.43.0",
     "ruff>=0.9.0",
@@ -53,8 +51,9 @@ _deps = [
     "hf_transfer>=0.1.4",
     "huggingface-hub[cli]>=0.19.2,<1.0",
     "isort>=5.12.0",
+    "latex2sympy2_extended>=1.0.6",
     "lighteval @ git+https://github.com/huggingface/lighteval.git@main",
-    "math-verify>=0.3.3",  # Used for math verification in grpo
+    "math-verify==0.5.2",  # Used for math verification in grpo
     "packaging>=23.0",
     "parameterized>=0.9.0",
     "pytest",


### PR DESCRIPTION
This pull request includes updates to the dependencies listed in the `setup.py` file. The changes primarily involve updating the versions of certain dependencies.

Dependency updates:

* Removed `latex2sympy2_extended` version `0.9.3` and added version `1.0.6`. [[1]](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L43-L44) [[2]](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7R54-R56)
* Updated `math-verify` from version `0.3.3` to `0.5.2`. [[1]](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L43-L44) [[2]](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7R54-R56)