### PR TITLE
Optimize memory usage in grpo configuration

### DIFF
--- a/recipes/doge/Doge-160M-R1/grpo/config_full.yaml
+++ b/recipes/doge/Doge-160M-R1/grpo/config_full.yaml
@@ -38,7 +38,9 @@ use_vllm: false
 vllm_device: auto
 vllm_gpu_memory_utilization: 0.7
 do_train: true
+max_steps: -1
 num_train_epochs: 1
+num_generations: 8 # Be consistent with preprocessing_num_workers or num_processes
 per_device_train_batch_size: 1
 do_eval: true
 evaluation_strategy: steps

--- a/recipes/doge/Doge-20M-R1/grpo/config_full.yaml
+++ b/recipes/doge/Doge-20M-R1/grpo/config_full.yaml
@@ -38,7 +38,9 @@ use_vllm: false
 vllm_device: auto
 vllm_gpu_memory_utilization: 0.7
 do_train: true
+max_steps: -1
 num_train_epochs: 1
+num_generations: 8 # Be consistent with preprocessing_num_workers or num_processes
 per_device_train_batch_size: 1
 do_eval: true
 evaluation_strategy: steps

--- a/recipes/doge/Doge-320M-R1/grpo/config_full.yaml
+++ b/recipes/doge/Doge-320M-R1/grpo/config_full.yaml
@@ -38,7 +38,9 @@ use_vllm: false
 vllm_device: auto
 vllm_gpu_memory_utilization: 0.7
 do_train: true
+max_steps: -1
 num_train_epochs: 1
+num_generations: 8 # Be consistent with preprocessing_num_workers or num_processes
 per_device_train_batch_size: 1
 do_eval: true
 evaluation_strategy: steps

--- a/recipes/doge/Doge-60M-R1/grpo/config_full.yaml
+++ b/recipes/doge/Doge-60M-R1/grpo/config_full.yaml
@@ -38,7 +38,9 @@ use_vllm: false
 vllm_device: auto
 vllm_gpu_memory_utilization: 0.7
 do_train: true
+max_steps: -1
 num_train_epochs: 1
+num_generations: 8 # Be consistent with preprocessing_num_workers or num_processes
 per_device_train_batch_size: 1
 do_eval: true
 evaluation_strategy: steps


### PR DESCRIPTION
Adjust the `num_generations` parameter to improve memory efficiency during training. Additionally, set `max_steps` to -1 for better control over the training process.