### PR TITLE
Update evaluation tasks for Base, Instruct, and Reason

### DIFF
--- a/evaluation/base/doge_base.txt
+++ b/evaluation/base/doge_base.txt
@@ -1,0 +1,8 @@
+original|mmlu|5|0
+lighteval|triviaqa|5|0
+lighteval|arc:easy|5|0
+leaderboard|arc:challenge|5|0
+lighteval|piqa|5|0
+leaderboard|hellaswag|5|0
+lighteval|openbookqa|5|0
+leaderboard|winogrande|5|0

--- a/evaluation/eval_downstream_tasks.ps1
+++ b/evaluation/eval_downstream_tasks.ps1
@@ -1,16 +1,24 @@
 
-$MODEL = "JingzeShi/Doge-20M"
+$MODEL = "SmallDoge/Doge-160M"
 $OUTPUT_DIR = "./lighteval_results"
 
 if ($MODEL -match "Instruct$") {
     lighteval accelerate "pretrained=$MODEL,max_length=2048,trust_remote_code=True" `
-    "extended|ifeval|5|0" `
+    "evaluation/instruct/doge_instruct.txt" `
     --override-batch-size 1 `
-    --output-dir $OUTPUT_DIR `
-    --use-chat-template
-} else {
+    --use-chat-template `
+    --output-dir $OUTPUT_DIR
+} elseif ($MODEL -match "Reason$") {
+    lighteval vllm "pretrained=$MODEL,max_model_length=32768,gpu_memory_utilisation=0.8,trust_remote_code=True" `
+    "evaluation/reason/doge_reason.txt" `
+    --custom-tasks evaluation/reason/tasks.py `
+    --override-batch-size 1 `
+    --use-chat-template `
+    --output-dir $OUTPUT_DIR
+}
+else {
     lighteval accelerate "pretrained=$MODEL,max_length=2048,trust_remote_code=True" `
-    "original|mmlu|5|0,lighteval|triviaqa|5|0,lighteval|arc:easy|5|0,leaderboard|arc:challenge|5|0,lighteval|piqa|5|0,leaderboard|hellaswag|5|0,lighteval|openbookqa|5|0,leaderboard|winogrande|5|0" `
+    "evaluation/base/doge_base.txt" `
     --override-batch-size 1 `
     --output-dir $OUTPUT_DIR
 }

--- a/evaluation/eval_downstream_tasks.sh
+++ b/evaluation/eval_downstream_tasks.sh
@@ -1,17 +1,24 @@
 #!/bin/bash
 
-MODEL="JingzeShi/Doge-20M"
+MODEL="SmallDoge/Doge-160M"
 OUTPUT_DIR="./lighteval_results"
 
 if [[ $MODEL =~ Instruct$ ]]; then
     lighteval accelerate "pretrained=$MODEL,max_length=2048,trust_remote_code=True" \
-    "extended|ifeval|5|0" \
+    "evaluation/instruct/doge_instruct.txt" \
     --override-batch-size 1 \
-    --output-dir $OUTPUT_DIR \
-    --use-chat-template
+    --use-chat-template \
+    --output-dir $OUTPUT_DIR
+elif [[ $MODEL =~ Reason$ ]]; then
+    lighteval vllm "pretrained=$MODEL,max_model_length=32768,gpu_memory_utilisation=0.8,trust_remote_code=True" \
+    "evaluation/reason/doge_reason.txt" \
+    --custom-tasks evaluation/reason/tasks.py \
+    --override-batch-size 1 \
+    --use-chat-template \
+    --output-dir $OUTPUT_DIR
 else
     lighteval accelerate "pretrained=$MODEL,max_length=2048,trust_remote_code=True" \
-    "original|mmlu|5|0,lighteval|triviaqa|5|0,lighteval|arc:easy|5|0,leaderboard|arc:challenge|5|0,lighteval|piqa|5|0,leaderboard|hellaswag|5|0,lighteval|openbookqa|5|0,leaderboard|winogrande|5|0" \
+    "evaluation/base/doge_base.txt" \
     --override-batch-size 1 \
     --output-dir $OUTPUT_DIR
 fi

--- a/evaluation/instruct/doge_instruct.txt
+++ b/evaluation/instruct/doge_instruct.txt
@@ -1,0 +1,6 @@
+extended|ifeval|0|0
+lighteval|arc:easy|0|0
+leaderboard|arc:challenge|0|0
+lighteval|piqa|0|0
+original|mmlu|0|0
+leaderboard|hellaswag|0|0

--- a/evaluation/reason/doge_reason.txt
+++ b/evaluation/reason/doge_reason.txt
@@ -1,0 +1,3 @@
+custom|aime24|0|0
+custom|math_500|0|0
+custom|gpqa:diamond|0|0

--- a/evaluation/reason/tasks.py
+++ b/evaluation/reason/tasks.py
@@ -1,0 +1,166 @@
+# Copyright 2025 The HuggingFace Team and The SmallDoge Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Custom evaluation tasks for LightEval."""
+
+import random
+
+from lighteval.metrics.dynamic_metrics import (
+    ExprExtractionConfig,
+    IndicesExtractionConfig,
+    LatexExtractionConfig,
+    multilingual_extractive_match_metric,
+)
+from lighteval.tasks.lighteval_task import LightevalTaskConfig
+from lighteval.tasks.requests import Doc
+from lighteval.utils.language import Language
+
+
+latex_gold_metric = multilingual_extractive_match_metric(
+    language=Language.ENGLISH,
+    fallback_mode="first_match",
+    precision=5,
+    gold_extraction_target=(LatexExtractionConfig(),),
+    # Match boxed first before trying other regexes
+    pred_extraction_target=(ExprExtractionConfig(), LatexExtractionConfig(boxed_match_priority=0)),
+    aggregation_function=max,
+)
+
+expr_gold_metric = multilingual_extractive_match_metric(
+    language=Language.ENGLISH,
+    fallback_mode="first_match",
+    precision=5,
+    gold_extraction_target=(ExprExtractionConfig(),),
+    # Match boxed first before trying other regexes
+    pred_extraction_target=(ExprExtractionConfig(), LatexExtractionConfig(boxed_match_priority=0)),
+    aggregation_function=max,
+)
+
+gpqa_metric = multilingual_extractive_match_metric(
+    language=Language.ENGLISH,
+    gold_extraction_target=[IndicesExtractionConfig(prefix_for_extraction="NativeLetters")],
+    pred_extraction_target=[IndicesExtractionConfig(prefix_for_extraction="NativeLetters")],
+    precision=5,
+)
+
+
+def prompt_fn(line, task_name: str = None):
+    """Assumes the model is either prompted to emit \\boxed{answer} or does so automatically"""
+    return Doc(
+        task_name=task_name,
+        query=line["problem"],
+        choices=[line["solution"]],
+        gold_index=0,
+    )
+
+
+def aime_prompt_fn(line, task_name: str = None):
+    return Doc(
+        task_name=task_name,
+        query=line["problem"],
+        choices=[line["answer"]],
+        gold_index=0,
+    )
+
+
+def gpqa_prompt_fn(line, task_name: str = None):
+    """Prompt template adapted from simple-evals: https://github.com/openai/simple-evals/blob/83ed7640a7d9cd26849bcb3340125002ef14abbe/common.py#L14"""
+    gold_index = random.randint(0, 3)
+    choices = [line["Incorrect Answer 1"], line["Incorrect Answer 2"], line["Incorrect Answer 3"]]
+    choices.insert(gold_index, line["Correct Answer"])
+    query_template = "Answer the following multiple choice question. The last line of your response should be of the following format: 'Answer: $LETTER' (without quotes) where LETTER is one of ABCD. Think step by step before answering.\n\n{Question}\n\nA) {A}\nB) {B}\nC) {C}\nD) {D}"
+    query = query_template.format(A=choices[0], B=choices[1], C=choices[2], D=choices[3], Question=line["Question"])
+
+    return Doc(
+        task_name=task_name,
+        query=query,
+        choices=["A", "B", "C", "D"],
+        gold_index=gold_index,
+        instruction=query,
+    )
+
+
+# Define tasks
+aime24 = LightevalTaskConfig(
+    name="aime24",
+    suite=["custom"],
+    prompt_function=aime_prompt_fn,
+    hf_repo="HuggingFaceH4/aime_2024",
+    hf_subset="default",
+    hf_avail_splits=["train"],
+    evaluation_splits=["train"],
+    few_shots_split=None,
+    few_shots_select=None,
+    generation_size=32768,
+    metric=[expr_gold_metric],
+    version=1,
+)
+# Part I from AIME 2025 exam: https://artofproblemsolving.com/wiki/index.php/2025_AIME_I?srsltid=AfmBOoof5gaaqlt3-l6LH7Tt6qmJZtl_2PQEDYlLFlMqhq9dLL8FMCRR
+aime25_part1 = LightevalTaskConfig(
+    name="aime25:part1",
+    suite=["custom"],
+    prompt_function=aime_prompt_fn,
+    hf_repo="open-r1/aime_2025_1",
+    hf_subset="default",
+    hf_avail_splits=["train"],
+    evaluation_splits=["train"],
+    few_shots_split=None,
+    few_shots_select=None,
+    generation_size=32768,
+    metric=[expr_gold_metric],
+    version=1,
+)
+math_500 = LightevalTaskConfig(
+    name="math_500",
+    suite=["custom"],
+    prompt_function=prompt_fn,
+    hf_repo="HuggingFaceH4/MATH-500",
+    hf_subset="default",
+    hf_avail_splits=["test"],
+    evaluation_splits=["test"],
+    few_shots_split=None,
+    few_shots_select=None,
+    generation_size=32768,
+    metric=[latex_gold_metric],
+    version=1,
+)
+gpqa_diamond = LightevalTaskConfig(
+    name="gpqa:diamond",
+    suite=["custom"],
+    prompt_function=gpqa_prompt_fn,
+    hf_repo="Idavidrein/gpqa",
+    hf_subset="gpqa_diamond",
+    hf_avail_splits=["train"],
+    evaluation_splits=["train"],
+    few_shots_split=None,
+    few_shots_select=None,
+    generation_size=32768,  # needed for reasoning models like R1
+    metric=[gpqa_metric],
+    stop_sequence=[],  # no stop sequence, will use eos token
+    trust_dataset=True,
+    version=1,
+)
+
+
+# Add tasks to the table
+TASKS_TABLE = []
+TASKS_TABLE.append(aime24)
+TASKS_TABLE.append(aime25_part1)
+TASKS_TABLE.append(math_500)
+TASKS_TABLE.append(gpqa_diamond)
+
+# MODULE LOGIC
+if __name__ == "__main__":
+    print([t["name"] for t in TASKS_TABLE])
+    print(len(TASKS_TABLE))


### PR DESCRIPTION
This pull request includes several updates to the evaluation scripts and configuration files to support new models and tasks. The most important changes include updating the model references, modifying evaluation scripts to handle different model types, and adding new evaluation tasks.

Model updates:

* [`evaluation/eval_downstream_tasks.ps1`](diffhunk://#diff-c8f9721d2f9c8880ce391ffa2283af73444b73a0e652ee21aab3c6f0ebbc0fb9L2-R21): Updated the model from `JingzeShi/Doge-20M` to `SmallDoge/Doge-160M` and added support for a new "Reason" model with specific configurations.
* [`evaluation/eval_downstream_tasks.sh`](diffhunk://#diff-bc5777a9b77db514f9baad35aa8f64b37b1d2cc267b8231c114fa39cabdd00eeL3-R21): Updated the model from `JingzeShi/Doge-20M` to `SmallDoge/Doge-160M` and added support for a new "Reason" model with specific configurations.

Evaluation task updates:

* [`evaluation/base/doge_base.txt`](diffhunk://#diff-f87b090ab2d3e776e869807f671ba8b31c5a9b41514d207ccec4f89621fc5f44R1-R8): Added multiple evaluation tasks including `mmlu`, `triviaqa`, `arc:easy`, `arc:challenge`, `piqa`, `hellaswag`, `openbookqa`, and `winogrande`.
* [`evaluation/instruct/doge_instruct.txt`](diffhunk://#diff-6656f9aa947c1fe64e924f0c48a78c13aaf7314589eb5b7538f7d33ce7931484R1-R6): Added evaluation tasks for `ifeval`, `arc:easy`, `arc:challenge`, `piqa`, `mmlu`, and `hellaswag`.
* [`evaluation/reason/doge_reason.txt`](diffhunk://#diff-fbea67a250fcb251e3dc800d564b3fa9ca65bec463cab6ece05875f2c5fa4222R1-R3): Added custom evaluation tasks for `aime24`, `math_500`, and `gpqa:diamond`.
* [`evaluation/reason/tasks.py`](diffhunk://#diff-aa354b43cd66a70d31be24f8091c584c301325e21986bebb27376b34b0247058R1-R166): Introduced a new file defining custom evaluation tasks and their configurations, including metrics and prompt functions.