### PR TITLE
Update fine-tuning utils for TRL>=0.15.0

### DIFF
--- a/examples/utils/concatenate_ft_datasets.py
+++ b/examples/utils/concatenate_ft_datasets.py
@@ -33,12 +33,12 @@ def concatenate_dpo_datasets(datasets_dir, save_dir, num_proc):
     dataset.save_to_disk(save_dir + "/dpo_dataset", num_proc=num_proc, num_shards={'train': 16, 'test': 1 })
 
 def concatenate_distill_datasets(datasets_dir, save_dir, num_proc):
-    bespoke_stratos_dataset = load_from_disk(datasets_dir + '/bespoke_stratos_processed')
+    open_thoughts_dataset = load_from_disk(datasets_dir + '/open_thoughts_processed')
     train_dataset : Dataset = concatenate_datasets([
-        bespoke_stratos_dataset['train'],
+        open_thoughts_dataset['train'],
     ])
     test_dataset : Dataset = concatenate_datasets([
-        bespoke_stratos_dataset['test'],
+        open_thoughts_dataset['test'],
     ])
     dataset = DatasetDict({
         'train': train_dataset,
@@ -48,12 +48,12 @@ def concatenate_distill_datasets(datasets_dir, save_dir, num_proc):
     dataset.save_to_disk(save_dir + "/distill_dataset", num_proc=num_proc, num_shards={'train': 16, 'test': 1 })
 
 def concatenate_grpo_datasets(datasets_dir, save_dir, num_proc):
-    numinamath_dataset = load_from_disk(datasets_dir + '/numinamath_processed')
+    openr1_math_dataset = load_from_disk(datasets_dir + '/openr1_math_processed')
     train_dataset : Dataset = concatenate_datasets([
-        numinamath_dataset['train'],
+        openr1_math_dataset['train'],
     ])
     test_dataset : Dataset = concatenate_datasets([
-        numinamath_dataset['test'],
+        openr1_math_dataset['test'],
     ])
     dataset = DatasetDict({
         'train': train_dataset,

--- a/examples/utils/download_ft_dataset.py
+++ b/examples/utils/download_ft_dataset.py
@@ -13,17 +13,17 @@ def download_ultrafeedback_binarized(save_dir, cache_dir, num_proc):
     print(dataset)
     dataset.save_to_disk(save_dir + "/ultrafeedback_binarized", num_proc=num_proc)
 
-def download_bespoke_stratos(save_dir, cache_dir, num_proc):
-    # Download bespoke_stratos dataset
-    dataset = load_dataset("HuggingFaceH4/Bespoke-Stratos-17k", num_proc=num_proc, cache_dir=cache_dir)
+def download_open_thoughts(save_dir, cache_dir, num_proc):
+    # Download open-thoughts dataset
+    dataset = load_dataset("open-thoughts/OpenThoughts-114k", "default", num_proc=num_proc, cache_dir=cache_dir)
     print(dataset)
-    dataset.save_to_disk(save_dir + "/bespoke_stratos", num_proc=num_proc)
+    dataset.save_to_disk(save_dir + "/open_thoughts", num_proc=num_proc)
 
-def download_numinamath(save_dir, cache_dir, num_proc):
-    # Download numinamath dataset
-    dataset = load_dataset("AI-MO/NuminaMath-TIR", num_proc=num_proc, cache_dir=cache_dir)
+def download_openr1_math(save_dir, cache_dir, num_proc):
+    # Download openr1-math dataset
+    dataset = load_dataset("open-r1/OpenR1-Math-220k", "default", num_proc=num_proc, cache_dir=cache_dir)
     print(dataset)
-    dataset.save_to_disk(save_dir + "/numinamath", num_proc=num_proc)
+    dataset.save_to_disk(save_dir + "/openr1_math", num_proc=num_proc)
 
 # You can also download other datasets
 
@@ -34,8 +34,8 @@ def main(args):
     download_ultrafeedback_binarized(args.save_dir, args.cache_dir, args.num_proc)
 
     # For Reasoning fine-tuning
-    download_bespoke_stratos(args.save_dir, args.cache_dir, args.num_proc)
-    download_numinamath(args.save_dir, args.cache_dir, args.num_proc)
+    download_open_thoughts(args.save_dir, args.cache_dir, args.num_proc)
+    download_openr1_math(args.save_dir, args.cache_dir, args.num_proc)
 
 
 if __name__ == "__main__":

--- a/examples/utils/preprocess_ft_datasets.py
+++ b/examples/utils/preprocess_ft_datasets.py
@@ -2,13 +2,17 @@ from transformers import AutoTokenizer
 from datasets import load_from_disk, DatasetDict
 from argparse import ArgumentParser
 
+# In the case of TRL>=0.15.0, apply_chat_template does not need to be applied here, but in the case of TRL<0.15.0, apply_chat_template needs to be applied here
 
 def smoltalk_map(example, tokenizer):
     messages = example['messages']
-    example['text'] = tokenizer.apply_chat_template(
-        messages,
-        tokenize=False,
-    )
+
+    # example['text'] = tokenizer.apply_chat_template(
+    #     messages,
+    #     tokenize=False,
+    # )
+
+    example['text'] = messages
     return example
 
 def ultrafeedback_binarized_map(example, tokenizer):
@@ -17,25 +21,36 @@ def ultrafeedback_binarized_map(example, tokenizer):
     chosen_messages = example["chosen"][-1:]
     rejected_messages = example["rejected"][-1:]
 
-    example['text_prompt'] = tokenizer.apply_chat_template(
-        prompt_messages,
-        tokenize=False,
-    )
-    example['text_chosen'] = tokenizer.apply_chat_template(
-        chosen_messages,
-        tokenize=False,
-    )
-    example['text_rejected'] = tokenizer.apply_chat_template(
-        rejected_messages,
-        tokenize=False,
-    )
+    # example['text_prompt'] = tokenizer.apply_chat_template(
+    #     prompt_messages,
+    #     tokenize=False,
+    # )
+    # example['text_chosen'] = tokenizer.apply_chat_template(
+    #     chosen_messages,
+    #     tokenize=False,
+    # )
+    # example['text_rejected'] = tokenizer.apply_chat_template(
+    #     rejected_messages,
+    #     tokenize=False,
+    # )
+
+    example['text_prompt'] = prompt_messages
+    example['text_chosen'] = chosen_messages
+    example['text_rejected'] = rejected_messages
 
     return example
 
-def bespoke_stratos_map(example, tokenizer):
-    messages = example['messages']
+def open_thoughts_map(example, tokenizer):
+    prompt = example['system']
+    messages = example['conversations']
+
+    conversations = [
+        {"role": "system", "content": prompt},
+        {"role": "user", "content": messages[0]["value"]},
+        {"role": "assistant", "content": messages[1]["value"]},
+    ]
     example['text'] = tokenizer.apply_chat_template(
-        messages,
+        conversations,
         tokenize=False,
     )
     return example
@@ -43,11 +58,11 @@ def bespoke_stratos_map(example, tokenizer):
 SYSTEM_PROMPT_FOR_GRPO = (
     "A conversation between User and Assistant. The user asks a question, and the Assistant solves it. The assistant "
     "first thinks about the reasoning process in the mind and then provides the user with the answer. The reasoning "
-    "process and answer are enclosed within <think> </think> and <answer> </answer> tags, respectively, i.e., "
-    "<think> reasoning process here </think><answer> answer here </answer>"
+    "process and answer are enclosed within <|begin_of_thought|> <|end_of_thought|> and <|begin_of_solution|> <|end_of_solution|> tags, respectively, i.e., "
+    "<|begin_of_thought|> reasoning process here <|end_of_thought|><|begin_of_solution|> answer here <|end_of_solution|>"
 )
 
-def numinamath_map(example):
+def openr1_math_map(example):
     return {
             "prompt": [
                 {"role": "system", "content": SYSTEM_PROMPT_FOR_GRPO},
@@ -99,37 +114,37 @@ def process_ultrafeedback_binarized(tokenizer, datasets_dir, num_proc):
     dataset.save_to_disk(datasets_dir + '/ultrafeedback_binarized_processed')
     return "ultrafeedback_binarized_processed"
 
-def process_bespoke_stratos(tokenizer, datasets_dir, num_proc):
-    dataset = load_from_disk(datasets_dir + '/bespoke_stratos')
+def process_open_thoughts(tokenizer, datasets_dir, num_proc):
+    dataset = load_from_disk(datasets_dir + '/open_thoughts')
     columns = dataset['train'].column_names
     dataset = dataset.map(
-        bespoke_stratos_map, 
+        open_thoughts_map, 
         fn_kwargs={
             'tokenizer': tokenizer
         },
         num_proc=num_proc,
         remove_columns=columns,
-        desc="Processing bespoke_stratos"
+        desc="Processing open_thoughts"
     )
     print(dataset)
-    dataset.save_to_disk(datasets_dir + '/bespoke_stratos_processed')
-    return "bespoke_stratos_processed"
+    dataset.save_to_disk(datasets_dir + '/open_thoughts_processed')
+    return "open_thoughts_processed"
 
-def process_numinamath(tokenizer, datasets_dir, num_proc):
-    dataset = load_from_disk(datasets_dir + '/numinamath')
+def process_openr1_math(tokenizer, datasets_dir, num_proc):
+    dataset = load_from_disk(datasets_dir + '/openr1_math')
     columns = dataset['train'].column_names
     dataset = dataset.map(
-        numinamath_map, 
+        openr1_math_map,
         num_proc=num_proc,
         remove_columns=columns,
-        desc="Processing numinamath"
+        desc="Processing openr1_math"
     )
     for split in dataset:
         if "messages" in dataset[split].column_names:
             dataset[split] = dataset[split].remove_columns("messages")
     print(dataset)
-    dataset.save_to_disk(datasets_dir + '/numinamath_processed')
-    return "numinamath_processed"
+    dataset.save_to_disk(datasets_dir + '/openr1_math_processed')
+    return "openr1_math_processed"
 
 
 def main(args):
@@ -142,11 +157,11 @@ def main(args):
     # Process ultrafeedback_binarized dataset
     process_ultrafeedback_binarized(tokenizer, args.datasets_dir, args.num_proc)
 
-    # Process bespoke_stratos dataset
-    process_bespoke_stratos(tokenizer, args.datasets_dir, args.num_proc)
+    # Process open-thoughts dataset
+    process_open_thoughts(tokenizer, args.datasets_dir, args.num_proc)
 
-    # Process numinamath dataset
-    process_numinamath(tokenizer, args.datasets_dir, args.num_proc)
+    # Process openr1-math dataset
+    process_openr1_math(tokenizer, args.datasets_dir, args.num_proc)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This pull request includes several changes to update dataset references and modify dataset processing functions. The most important changes include renaming datasets, updating dataset loading and saving paths, and adjusting dataset processing logic.

### Dataset Reference Updates:
* Changed dataset references from `bespoke_stratos` to `open_thoughts` in `concatenate_distill_datasets` and `download_ft_dataset.py` [[1]](diffhunk://#diff-2117da2594c78ed7ab97acbe3fe7040f268782fdd240c7fe74b79d7433dc7e82L36-R41) [[2]](diffhunk://#diff-f0cc3943a1263945b8f17ae784eee0bf546f6f37e7203d348b77f0aefc20f373L16-R26).
* Changed dataset references from `numinamath` to `openr1_math` in `concatenate_grpo_datasets` and `download_ft_dataset.py` [[1]](diffhunk://#diff-2117da2594c78ed7ab97acbe3fe7040f268782fdd240c7fe74b79d7433dc7e82L51-R56) [[2]](diffhunk://#diff-f0cc3943a1263945b8f17ae784eee0bf546f6f37e7203d348b77f0aefc20f373L16-R26).

### Dataset Processing Logic:
* Updated `preprocess_ft_datasets.py` to remove the application of `apply_chat_template` for TRL>=0.15.0 and directly use message content for `smoltalk_map` and `ultrafeedback_binarized_map` [[1]](diffhunk://#diff-df4b79e49975b54691c6164cef7fd28a1a12222f61d30b9b8b0c7f962565df6dR5-R15) [[2]](diffhunk://#diff-df4b79e49975b54691c6164cef7fd28a1a12222f61d30b9b8b0c7f962565df6dL20-R65).
* Renamed processing functions from `process_bespoke_stratos` to `process_open_thoughts` and from `process_numinamath` to `process_openr1_math` in `preprocess_ft_datasets.py`.

### Main Function Adjustments:
* Updated calls in the `main` function of `preprocess_ft_datasets.py` and `download_ft_dataset.py` to reflect the new dataset names and processing functions [[1]](diffhunk://#diff-f0cc3943a1263945b8f17ae784eee0bf546f6f37e7203d348b77f0aefc20f373L37-R38) [[2]](diffhunk://#diff-df4b79e49975b54691c6164cef7fd28a1a12222f61d30b9b8b0c7f962565df6dL145-R164).