### PR TITLE
Update namesof eval task

### DIFF
--- a/evaluation/base/doge_base.txt
+++ b/evaluation/base/doge_base.txt
@@ -2,6 +2,6 @@ leaderboard|hellaswag|5|0
 custom|arc|5|0
 lighteval|piqa|5|0
 custom|mmlu|5|0
-lighteval|trivia_qa|5|0
+lighteval|triviaqa|5|0
 leaderboard|winogrande|5|0
-lighteval|openbook_qa|5|0
+lighteval|openbookqa|5|0

--- a/src/small_doge/models/modeling_doge.py
+++ b/src/small_doge/models/modeling_doge.py
@@ -864,14 +864,7 @@ class DogeModel(DogePreTrainedModel):
         past_key_values: Cache,
         output_attentions: bool,
     ):
-        if self.config._attn_implementation == "flash_attention_2":
-            if attention_mask is not None and (attention_mask == 0.0).any():
-                return attention_mask
-            return None
-
-        # For SDPA, when possible, we will rely on its `is_causal` argument instead of its `attn_mask` argument, in
-        # order to dispatch on Flash Attention 2. This feature is not compatible with static cache, as SDPA will fail
-        # to infer the attention mask.
+        # We have to provide attention_mask for dynamic mask computation
         past_seen_tokens = past_key_values.get_seq_length() if past_key_values is not None else 0
         using_static_cache = isinstance(past_key_values, StaticCache)
 


### PR DESCRIPTION
This pull request includes changes to the `evaluation/base/doge_base.txt` and `src/small_doge/models/modeling_doge.py` files. The changes involve correcting evaluation dataset names and updating the causal mask logic in the model.

Dataset name corrections:
* [`evaluation/base/doge_base.txt`](diffhunk://#diff-f87b090ab2d3e776e869807f671ba8b31c5a9b41514d207ccec4f89621fc5f44L5-R7): Corrected the names of the `triviaqa` and `openbookqa` datasets to match the expected format.

Causal mask logic update:
* [`src/small_doge/models/modeling_doge.py`](diffhunk://#diff-2dfe4091abce41550f065891428157efa3c1321e9dcf54751424eed4c9233446L867-R867): Removed the conditional logic for `flash_attention_2` and added a comment to clarify the need for providing `attention_mask` for dynamic mask computation.