### PR TITLE
Fix nits

### DIFF
--- a/src/small_doge/models/modeling_doge.py
+++ b/src/small_doge/models/modeling_doge.py
@@ -611,7 +611,7 @@ class DogePreTrainedModel(PreTrainedModel):
 
     def _init_weights(self, module):
         std = self.config.initializer_range
-        if isinstance(module, (nn.Linear)):
+        if isinstance(module, nn.Linear):
             module.weight.data.normal_(mean=0.0, std=std)
             if module.bias is not None:
                 module.bias.data.zero_()


### PR DESCRIPTION
This pull request includes a minor change to the `DogePreTrainedModel` class in the `src/small_doge/models/modeling_doge.py` file. The change corrects the syntax used to check the type of the `module` parameter.

* [`src/small_doge/models/modeling_doge.py`](diffhunk://#diff-2dfe4091abce41550f065891428157efa3c1321e9dcf54751424eed4c9233446L614-R614): Corrected the syntax in the `if` statement to properly check if `module` is an instance of `nn.Linear`.