### PR TITLE
Hybrid DMA with sliding window

### DIFF
--- a/src/small_doge/models/configuration_doge.py
+++ b/src/small_doge/models/configuration_doge.py
@@ -111,6 +111,8 @@ class DogeConfig(PretrainedConfig):
             If it is not specified, will default to `num_attention_heads`.
         attention_dropout (`float`, *optional*, defaults to 0.0):
             The dropout ratio for the attention probabilities.
+        keep_window_size (`int`, *optional*, defaults to 2048):
+            The window size of tokens that are not dynamically masked, and dynamic masking is only performed when the sequence length exceeds this value.
         dynamic_mask_ratio (`float`, *optional*, defaults to 0.0):
             The ratio to control the proportion of the dynamic mask filled with the minimum value. For more details checkout [this paper](https://arxiv.org/pdf/2412.11834).
         is_moe (`bool`, *optional*, defaults to `False`):
@@ -174,6 +176,7 @@ class DogeConfig(PretrainedConfig):
         num_attention_heads=8,
         num_key_value_heads=None,
         attention_dropout=0.0,
+        keep_window_size=2048,
         dynamic_mask_ratio=0.0,
         is_moe=False,
         num_experts=2048,
@@ -199,6 +202,7 @@ class DogeConfig(PretrainedConfig):
         self.num_attention_heads = num_attention_heads
         self.num_key_value_heads = num_key_value_heads
         self.attention_dropout = attention_dropout
+        self.keep_window_size = keep_window_size
         self.dynamic_mask_ratio = dynamic_mask_ratio
         self.is_moe = is_moe
         self.num_experts = num_experts

--- a/src/small_doge/models/modeling_doge.py
+++ b/src/small_doge/models/modeling_doge.py
@@ -333,6 +333,7 @@ class DogeDynamicMaskAttention(nn.Module):
         self.num_key_value_groups = config.num_attention_heads // config.num_key_value_heads
         self.scaling = self.head_dim**-0.5
         self.attention_dropout = config.attention_dropout
+        self.keep_window_size = config.keep_window_size
         self.dynamic_mask_ratio = config.dynamic_mask_ratio
 
         self.q_proj = nn.Linear(
@@ -385,6 +386,7 @@ class DogeDynamicMaskAttention(nn.Module):
         attn_mask = self.prepare_dynamic_mask(
             hidden_states=hidden_states,
             dynamic_mask=dynamic_mask,
+            keep_window_size=self.keep_window_size,
             dynamic_mask_ratio=self.dynamic_mask_ratio,
             attention_mask=attention_mask,
         )
@@ -418,31 +420,34 @@ class DogeDynamicMaskAttention(nn.Module):
         self,
         hidden_states: torch.Tensor,
         dynamic_mask: torch.Tensor,
+        keep_window_size: int = 2048,
         dynamic_mask_ratio: float = 0.0,
         attention_mask: Optional[torch.Tensor] = None,
     ):
         """
+        The core idea of DMA is to calculate the dynamic attention mask to mask the tokens that should be masked, so as to form sparse attention.
+
         Combine `dynamic_mask` with `attention_mask` to generate the final `attn_mask`.
 
         Args:
             hidden_states (`torch.Tensor`): The input hidden_states, used to determine the minimum value of the current input precision.
             dynamic_mask (`torch.Tensor`): dynamic mask of shape `(batch_size, num_heads, key_sequence_length)`.
-            dynamic_mask_ratio (`float`, *optional*): Ratio from 0.0 to 1.0 used to control the proportion of the dynamic mask filled with the minimum value.
+            keep_window_size (`int`): The window size of tokens that are not dynamically masked, and dynamic masking is only performed when the sequence length exceeds this value.
+            dynamic_mask_ratio (`float`): Ratio from 0.0 to 1.0 used to control the proportion of the dynamic mask filled with the minimum value.
             attention_mask (`torch.Tensor`, *optional*): attention mask of shape `(batch_size, 1, query_sequence_length, key_sequence_length)`.
         """
-        attn_mask = None
-        if dynamic_mask is not None:
-            attn_mask = dynamic_mask[:, :, None, :]
+        attn_mask = dynamic_mask[:, :, None, :]
+        if dynamic_mask.shape[-1] > keep_window_size:
             if 0.0 < dynamic_mask_ratio < 1.0:
                 min_type = torch.finfo(hidden_states.dtype).min
                 num_dynamic_mask = int(attn_mask.shape[-1] * dynamic_mask_ratio)
                 if num_dynamic_mask > 0:
                     rate_value = torch.kthvalue(attn_mask, num_dynamic_mask, dim=-1, keepdim=True).values
                     attn_mask = attn_mask.masked_fill(attn_mask < rate_value, min_type)
-            if attention_mask is not None:
-                attn_mask = attn_mask + attention_mask[:, :, :, : attn_mask.shape[-1]]
-        else:
-            attn_mask = attention_mask
+            else:
+                ValueError("`dynamic_mask_ratio` should be in the range (0.0, 1.0)")
+        if attention_mask is not None:
+            attn_mask = attn_mask + attention_mask[:, :, :, : attn_mask.shape[-1]]
 
         return attn_mask
 

--- a/src/small_doge/models/modular_doge.py
+++ b/src/small_doge/models/modular_doge.py
@@ -151,6 +151,8 @@ class DogeConfig(PretrainedConfig):
             If it is not specified, will default to `num_attention_heads`.
         attention_dropout (`float`, *optional*, defaults to 0.0):
             The dropout ratio for the attention probabilities.
+        keep_window_size (`int`, *optional*, defaults to 2048):
+            The window size of tokens that are not dynamically masked, and dynamic masking is only performed when the sequence length exceeds this value.
         dynamic_mask_ratio (`float`, *optional*, defaults to 0.0):
             The ratio to control the proportion of the dynamic mask filled with the minimum value. For more details checkout [this paper](https://arxiv.org/pdf/2412.11834).
         is_moe (`bool`, *optional*, defaults to `False`):
@@ -211,6 +213,7 @@ class DogeConfig(PretrainedConfig):
         num_attention_heads=8,
         num_key_value_heads=None,
         attention_dropout=0.0,
+        keep_window_size=2048,
         dynamic_mask_ratio=0.0,
         is_moe=False,
         num_experts=2048,
@@ -236,6 +239,7 @@ class DogeConfig(PretrainedConfig):
         self.num_attention_heads = num_attention_heads
         self.num_key_value_heads = num_key_value_heads
         self.attention_dropout = attention_dropout
+        self.keep_window_size = keep_window_size
         self.dynamic_mask_ratio = dynamic_mask_ratio
         self.is_moe = is_moe
         self.num_experts = num_experts
@@ -438,6 +442,7 @@ class DogeDynamicMaskAttention(nn.Module):
         self.num_key_value_groups = config.num_attention_heads // config.num_key_value_heads
         self.scaling = self.head_dim**-0.5
         self.attention_dropout = config.attention_dropout
+        self.keep_window_size = config.keep_window_size
         self.dynamic_mask_ratio = config.dynamic_mask_ratio
 
         self.q_proj = nn.Linear(
@@ -490,6 +495,7 @@ class DogeDynamicMaskAttention(nn.Module):
         attn_mask = self.prepare_dynamic_mask(
             hidden_states=hidden_states,
             dynamic_mask=dynamic_mask,
+            keep_window_size=self.keep_window_size,
             dynamic_mask_ratio=self.dynamic_mask_ratio,
             attention_mask=attention_mask,
         )
@@ -523,31 +529,34 @@ class DogeDynamicMaskAttention(nn.Module):
         self,
         hidden_states: torch.Tensor,
         dynamic_mask: torch.Tensor,
+        keep_window_size: int = 2048,
         dynamic_mask_ratio: float = 0.0,
         attention_mask: Optional[torch.Tensor] = None,
     ):
         """
+        The core idea of DMA is to calculate the dynamic attention mask to mask the tokens that should be masked, so as to form sparse attention.
+
         Combine `dynamic_mask` with `attention_mask` to generate the final `attn_mask`.
 
         Args:
             hidden_states (`torch.Tensor`): The input hidden_states, used to determine the minimum value of the current input precision.
             dynamic_mask (`torch.Tensor`): dynamic mask of shape `(batch_size, num_heads, key_sequence_length)`.
-            dynamic_mask_ratio (`float`, *optional*): Ratio from 0.0 to 1.0 used to control the proportion of the dynamic mask filled with the minimum value.
+            keep_window_size (`int`): The window size of tokens that are not dynamically masked, and dynamic masking is only performed when the sequence length exceeds this value.
+            dynamic_mask_ratio (`float`): Ratio from 0.0 to 1.0 used to control the proportion of the dynamic mask filled with the minimum value.
             attention_mask (`torch.Tensor`, *optional*): attention mask of shape `(batch_size, 1, query_sequence_length, key_sequence_length)`.
         """
-        attn_mask = None
-        if dynamic_mask is not None:
-            attn_mask = dynamic_mask[:, :, None, :]
+        attn_mask = dynamic_mask[:, :, None, :]
+        if dynamic_mask.shape[-1] > keep_window_size:
             if 0.0 < dynamic_mask_ratio < 1.0:
                 min_type = torch.finfo(hidden_states.dtype).min
                 num_dynamic_mask = int(attn_mask.shape[-1] * dynamic_mask_ratio)
                 if num_dynamic_mask > 0:
                     rate_value = torch.kthvalue(attn_mask, num_dynamic_mask, dim=-1, keepdim=True).values
                     attn_mask = attn_mask.masked_fill(attn_mask < rate_value, min_type)
-            if attention_mask is not None:
-                attn_mask = attn_mask + attention_mask[:, :, :, : attn_mask.shape[-1]]
-        else:
-            attn_mask = attention_mask
+            else:
+                ValueError("`dynamic_mask_ratio` should be in the range (0.0, 1.0)")
+        if attention_mask is not None:
+            attn_mask = attn_mask + attention_mask[:, :, :, : attn_mask.shape[-1]]
 
         return attn_mask
 


### PR DESCRIPTION
This pull request introduces a new `keep_window_size` parameter to the Doge model configuration, which is used to control the window size of tokens that are not dynamically masked. The changes are applied to both `configuration_doge.py` and `modular_doge.py` files, and the new parameter is integrated into the model initialization and dynamic mask preparation methods.

### Configuration changes:
* Added `keep_window_size` parameter to the `DogeConfig` class in `src/small_doge/models/configuration_doge.py` and `src/small_doge/models/modular_doge.py` with a default value of 2048. [[1]](diffhunk://#diff-bf1b7412b5f22687f96f4b00d39a2ab3208e04b51dfd292e64b995858f541a26R114-R115) [[2]](diffhunk://#diff-c2a11bc00cd9856ee25a259b7cd0f7cd6a46dda84a29bbd3a7fb76cedf8beecbR154-R155)
* Updated the `__init__` method in `DogeConfig` to include the `keep_window_size` parameter. [[1]](diffhunk://#diff-bf1b7412b5f22687f96f4b00d39a2ab3208e04b51dfd292e64b995858f541a26R179) [[2]](diffhunk://#diff-c2a11bc00cd9856ee25a259b7cd0f7cd6a46dda84a29bbd3a7fb76cedf8beecbR216)
* Assigned the `keep_window_size` parameter in the `__init__` method. [[1]](diffhunk://#diff-bf1b7412b5f22687f96f4b00d39a2ab3208e04b51dfd292e64b995858f541a26R205) [[2]](diffhunk://#diff-c2a11bc00cd9856ee25a259b7cd0f7cd6a46dda84a29bbd3a7fb76cedf8beecbR242)

### Model changes:
* Added `keep_window_size` to the model initialization in `src/small_doge/models/modeling_doge.py` and `src/small_doge/models/modular_doge.py`. [[1]](diffhunk://#diff-2dfe4091abce41550f065891428157efa3c1321e9dcf54751424eed4c9233446R336) [[2]](diffhunk://#diff-c2a11bc00cd9856ee25a259b7cd0f7cd6a46dda84a29bbd3a7fb76cedf8beecbR445)
* Integrated `keep_window_size` into the `forward` method to pass it to `prepare_dynamic_mask`. [[1]](diffhunk://#diff-2dfe4091abce41550f065891428157efa3c1321e9dcf54751424eed4c9233446R389) [[2]](diffhunk://#diff-c2a11bc00cd9856ee25a259b7cd0f7cd6a46dda84a29bbd3a7fb76cedf8beecbR498)

### Dynamic mask preparation:
* Updated the `prepare_dynamic_mask` method to accept `keep_window_size` and use it to determine whether dynamic masking should be applied based on the sequence length. [[1]](diffhunk://#diff-2dfe4091abce41550f065891428157efa3c1321e9dcf54751424eed4c9233446R423-L445) [[2]](diffhunk://#diff-c2a11bc00cd9856ee25a259b7cd0f7cd6a46dda84a29bbd3a7fb76cedf8beecbR532-L550)