### PR TITLE
Update valid tokens greater than window size

### DIFF
--- a/src/small_doge/models/modeling_doge.py
+++ b/src/small_doge/models/modeling_doge.py
@@ -438,7 +438,7 @@ class DogeDynamicMaskAttention(nn.Module):
         """
         attn_mask = dynamic_mask[:, :, None, :]
         if dynamic_mask.shape[-1] > keep_window_size:
-            if 0.0 < dynamic_mask_ratio < 1.0:
+            if 0.0 < dynamic_mask_ratio <= 1.0:
                 min_type = torch.finfo(hidden_states.dtype).min
                 num_dynamic_mask = int((attn_mask.shape[-1] - keep_window_size) * dynamic_mask_ratio)
                 if num_dynamic_mask > 0:

--- a/src/small_doge/models/modeling_doge.py
+++ b/src/small_doge/models/modeling_doge.py
@@ -440,7 +440,7 @@ class DogeDynamicMaskAttention(nn.Module):
         if dynamic_mask.shape[-1] > keep_window_size:
             if 0.0 < dynamic_mask_ratio < 1.0:
                 min_type = torch.finfo(hidden_states.dtype).min
-                num_dynamic_mask = int(attn_mask.shape[-1] * dynamic_mask_ratio)
+                num_dynamic_mask = int((attn_mask.shape[-1] - keep_window_size) * dynamic_mask_ratio)
                 if num_dynamic_mask > 0:
                     rate_value = torch.kthvalue(attn_mask, num_dynamic_mask, dim=-1, keepdim=True).values
                     attn_mask = attn_mask.masked_fill(attn_mask < rate_value, min_type)

--- a/src/small_doge/models/modular_doge.py
+++ b/src/small_doge/models/modular_doge.py
@@ -549,7 +549,7 @@ class DogeDynamicMaskAttention(nn.Module):
         if dynamic_mask.shape[-1] > keep_window_size:
             if 0.0 < dynamic_mask_ratio < 1.0:
                 min_type = torch.finfo(hidden_states.dtype).min
-                num_dynamic_mask = int(attn_mask.shape[-1] * dynamic_mask_ratio)
+                num_dynamic_mask = int((attn_mask.shape[-1] - keep_window_size) * dynamic_mask_ratio)
                 if num_dynamic_mask > 0:
                     rate_value = torch.kthvalue(attn_mask, num_dynamic_mask, dim=-1, keepdim=True).values
                     attn_mask = attn_mask.masked_fill(attn_mask < rate_value, min_type)

--- a/src/small_doge/models/modular_doge.py
+++ b/src/small_doge/models/modular_doge.py
@@ -547,7 +547,7 @@ class DogeDynamicMaskAttention(nn.Module):
         """
         attn_mask = dynamic_mask[:, :, None, :]
         if dynamic_mask.shape[-1] > keep_window_size:
-            if 0.0 < dynamic_mask_ratio < 1.0:
+            if 0.0 < dynamic_mask_ratio <= 1.0:
                 min_type = torch.finfo(hidden_states.dtype).min
                 num_dynamic_mask = int((attn_mask.shape[-1] - keep_window_size) * dynamic_mask_ratio)
                 if num_dynamic_mask > 0:


### PR DESCRIPTION
This pull request includes changes to the `prepare_dynamic_mask` function in two different files to correct the calculation of `num_dynamic_mask` and adjust the condition for `dynamic_mask_ratio`.

Changes to `prepare_dynamic_mask` function:

* [`src/small_doge/models/modeling_doge.py`](diffhunk://#diff-2dfe4091abce41550f065891428157efa3c1321e9dcf54751424eed4c9233446L441-R443): Adjusted the condition to allow `dynamic_mask_ratio` to be exactly 1.0 and corrected the calculation of `num_dynamic_mask` to subtract `keep_window_size` from `attn_mask.shape[-1]`.
* [`src/small_doge/models/modular_doge.py`](diffhunk://#diff-c2a11bc00cd9856ee25a259b7cd0f7cd6a46dda84a29bbd3a7fb76cedf8beecbL550-R552): Similar adjustments as above to allow `dynamic_mask_ratio` to be exactly 1.0 and correct the calculation of `num_dynamic_mask`.