### PR TITLE
Add scaling parameter for unfreeze

### DIFF
--- a/src/small_doge/pt.py
+++ b/src/small_doge/pt.py
@@ -51,6 +51,8 @@ def set_moe_warmup_phase(model: DogeForCausalLM):
         r"^model\.layers\.\d+\.feed_forward\.keys$",
         r"^model\.layers\.\d+\.feed_forward\.down_embed\.weight$",
         r"^model\.layers\.\d+\.feed_forward\.up_embed\.weight$",
+        r"^model\.layers\.\d+\.feed_forward\.mlp_scaling$",
+        r"^model\.layers\.\d+\.feed_forward\.moe_scaling$",
     ]
 
     # Freeze all parameters first


### PR DESCRIPTION
This pull request includes a change to the `set_moe_warmup_phase` function in the `src/small_doge/pt.py` file. The change adds new regular expressions to the list of patterns used for identifying specific model parameters.

* [`src/small_doge/pt.py`](diffhunk://#diff-960c9033062defa6afe110f7600dcd9cafa19f453ebf6b73fcb7b290c120d964R54-R55): Added regular expressions for `mlp_scaling` and `moe_scaling` to the list of patterns in the `set_moe_warmup_phase` function.