### PR TITLE
Add MoE recipes

### DIFF
--- a/recipes/doge/Doge-1.4B-MoE/config_full.yaml
+++ b/recipes/doge/Doge-1.4B-MoE/config_full.yaml
@@ -1,0 +1,77 @@
+# Logging and Output arguments
+log_level: info
+logging_strategy: steps
+logging_steps: 100
+report_to:
+- tensorboard
+- wandb
+save_strategy: steps
+save_steps: 100
+output_dir: data/Doge-320M-MoE
+overwrite_output_dir: true
+push_to_hub: true
+private: true
+# token: <your-token>
+hub_model_id: Doge-320M-MoE
+hub_strategy: every_save
+
+# Model arguments
+model_config:
+  vocab_size: 32768
+  hidden_size: 1024
+  intermediate_size: 2048
+  num_hidden_layers: 32
+  hidden_dropout: 0.0
+  hidden_act: "silu"
+  use_cache: True
+  tie_word_embeddings: True
+  max_position_embeddings: 2048
+  rope_theta: 10000.0
+  rope_scaling:
+    rope_type: dynamic
+    factor: 4.0
+    original_max_position_embeddings: 2048
+  num_attention_heads: 8
+  num_key_value_heads: 4
+  is_moe: True
+  num_experts: 16384
+  num_experts_per_tok: 64
+  expert_retrieval_size: 64
+
+model_name_or_path: SmallDoge/Doge-320M
+torch_dtype: bfloat16
+
+# Data training arguments
+dataset_name: ./datasets/pt_dataset
+dataset_configs:
+- all
+
+# PT trainer arguments
+preprocessing_num_workers: 1 # Equal to the number of Gpus you are using
+seed: 233
+do_train: True
+max_steps: 32000
+per_device_train_batch_size: 1
+do_eval: True
+eval_strategy: steps
+eval_steps: 100
+per_device_eval_batch_size: 1
+optim: adamw_torch_fused
+adam_beta1: 0.9
+adam_beta2: 0.95
+adam_epsilon: 1.0e-8
+learning_rate: 2.0e-3
+lr_scheduler_type: warmup_stable_decay
+lr_scheduler_kwargs:
+  warmup_type: linear
+  decay_type: linear
+  num_decay_steps: 3200
+  min_lr_ratio: 0.0
+warmup_steps: 3200
+weight_decay: 0.01
+gradient_accumulation_steps: 1024
+gradient_checkpointing: true
+gradient_checkpointing_kwargs:
+  use_reentrant: false
+max_grad_norm: 1.0
+bf16: True

--- a/recipes/doge/Doge-120M-MoE/config_full.yaml
+++ b/recipes/doge/Doge-120M-MoE/config_full.yaml
@@ -1,0 +1,77 @@
+# Logging and Output arguments
+log_level: info
+logging_strategy: steps
+logging_steps: 100
+report_to:
+- tensorboard
+- wandb
+save_strategy: steps
+save_steps: 100
+output_dir: data/Doge-60M-MoE
+overwrite_output_dir: true
+push_to_hub: true
+private: true
+# token: <your-token>
+hub_model_id: Doge-60M-MoE
+hub_strategy: every_save
+
+# Model arguments
+model_config:
+  vocab_size: 32768
+  hidden_size: 512
+  intermediate_size: 1024
+  num_hidden_layers: 16
+  hidden_dropout: 0.0
+  hidden_act: "silu"
+  use_cache: True
+  tie_word_embeddings: True
+  max_position_embeddings: 2048
+  rope_theta: 10000.0
+  rope_scaling:
+    rope_type: dynamic
+    factor: 4.0
+    original_max_position_embeddings: 2048
+  num_attention_heads: 4
+  num_key_value_heads: 2
+  is_moe: True
+  num_experts: 4096
+  num_experts_per_tok: 32
+  expert_retrieval_size: 64
+
+model_name_or_path: SmallDoge/Doge-60M
+torch_dtype: bfloat16
+
+# Data training arguments
+dataset_name: ./datasets/pt_dataset
+dataset_configs:
+- all
+
+# PT trainer arguments
+preprocessing_num_workers: 1 # Equal to the number of Gpus you are using
+seed: 233
+do_train: True
+max_steps: 16000
+per_device_train_batch_size: 1
+do_eval: True
+eval_strategy: steps
+eval_steps: 100
+per_device_eval_batch_size: 1
+optim: adamw_torch_fused
+adam_beta1: 0.9
+adam_beta2: 0.95
+adam_epsilon: 1.0e-8
+learning_rate: 6.0e-3
+lr_scheduler_type: warmup_stable_decay
+lr_scheduler_kwargs:
+  warmup_type: linear
+  decay_type: linear
+  num_decay_steps: 1600
+  min_lr_ratio: 0.0
+warmup_steps: 1600
+weight_decay: 0.01
+gradient_accumulation_steps: 512
+gradient_checkpointing: true
+gradient_checkpointing_kwargs:
+  use_reentrant: false
+max_grad_norm: 1.0
+bf16: True

--- a/recipes/doge/Doge-20M-MoE/config_full.yaml
+++ b/recipes/doge/Doge-20M-MoE/config_full.yaml
@@ -1,0 +1,77 @@
+# Logging and Output arguments
+log_level: info
+logging_strategy: steps
+logging_steps: 100
+report_to:
+- tensorboard
+- wandb
+save_strategy: steps
+save_steps: 100
+output_dir: data/Doge-20M-MoE
+overwrite_output_dir: true
+push_to_hub: true
+private: true
+# token: <your-token>
+hub_model_id: Doge-20M-MoE
+hub_strategy: every_save
+
+# Model arguments
+model_config:
+  vocab_size: 32768
+  hidden_size: 256
+  intermediate_size: 512
+  num_hidden_layers: 8
+  hidden_dropout: 0.0
+  hidden_act: "silu"
+  use_cache: True
+  tie_word_embeddings: True
+  max_position_embeddings: 2048
+  rope_theta: 10000.0
+  rope_scaling:
+    rope_type: dynamic
+    factor: 4.0
+    original_max_position_embeddings: 2048
+  num_attention_heads: 2
+  num_key_value_heads: 1
+  is_moe: True
+  num_experts: 1024
+  num_experts_per_tok: 16
+  expert_retrieval_size: 64
+
+model_name_or_path: SmallDoge/Doge-20M
+torch_dtype: bfloat16
+
+# Data training arguments
+dataset_name: ./datasets/pt_dataset
+dataset_configs:
+- all
+
+# PT trainer arguments
+preprocessing_num_workers: 1 # Equal to the number of Gpus you are using
+seed: 233
+do_train: True
+max_steps: 8000
+per_device_train_batch_size: 1
+do_eval: True
+eval_strategy: steps
+eval_steps: 100
+per_device_eval_batch_size: 1
+optim: adamw_torch_fused
+adam_beta1: 0.9
+adam_beta2: 0.95
+adam_epsilon: 1.0e-8
+learning_rate: 8.0e-3
+lr_scheduler_type: warmup_stable_decay
+lr_scheduler_kwargs:
+  warmup_type: linear
+  decay_type: linear
+  num_decay_steps: 800
+  min_lr_ratio: 0.0
+warmup_steps: 800
+weight_decay: 0.01
+gradient_accumulation_steps: 256
+gradient_checkpointing: true
+gradient_checkpointing_kwargs:
+  use_reentrant: false
+max_grad_norm: 1.0
+bf16: True

--- a/recipes/doge/Doge-480M-MoE/config_full.yaml
+++ b/recipes/doge/Doge-480M-MoE/config_full.yaml
@@ -1,0 +1,77 @@
+# Logging and Output arguments
+log_level: info
+logging_strategy: steps
+logging_steps: 100
+report_to:
+- tensorboard
+- wandb
+save_strategy: steps
+save_steps: 100
+output_dir: data/Doge-160M-MoE
+overwrite_output_dir: true
+push_to_hub: true
+private: true
+# token: <your-token>
+hub_model_id: Doge-160M-MoE
+hub_strategy: every_save
+
+# Model arguments
+model_config:
+  vocab_size: 32768
+  hidden_size: 768
+  intermediate_size: 1536
+  num_hidden_layers: 24
+  hidden_dropout: 0.0
+  hidden_act: "silu"
+  use_cache: True
+  tie_word_embeddings: True
+  max_position_embeddings: 2048
+  rope_theta: 10000.0
+  rope_scaling:
+    rope_type: dynamic
+    factor: 4.0
+    original_max_position_embeddings: 2048
+  num_attention_heads: 6
+  num_key_value_heads: 3
+  is_moe: True
+  num_experts: 9216
+  num_experts_per_tok: 48
+  expert_retrieval_size: 64
+
+model_name_or_path: SmallDoge/Doge-160M
+torch_dtype: bfloat16
+
+# Data training arguments
+dataset_name: ./datasets/pt_dataset
+dataset_configs:
+- all
+
+# PT trainer arguments
+preprocessing_num_workers: 1 # Equal to the number of Gpus you are using
+seed: 233
+do_train: True
+max_steps: 24000
+per_device_train_batch_size: 1
+do_eval: True
+eval_strategy: steps
+eval_steps: 100
+per_device_eval_batch_size: 1
+optim: adamw_torch_fused
+adam_beta1: 0.9
+adam_beta2: 0.95
+adam_epsilon: 1.0e-8
+learning_rate: 4.0e-3
+lr_scheduler_type: warmup_stable_decay
+lr_scheduler_kwargs:
+  warmup_type: linear
+  decay_type: linear
+  num_decay_steps: 2400
+  min_lr_ratio: 0.0
+warmup_steps: 2400
+weight_decay: 0.01
+gradient_accumulation_steps: 768
+gradient_checkpointing: true
+gradient_checkpointing_kwargs:
+  use_reentrant: false
+max_grad_norm: 1.0
+bf16: True


### PR DESCRIPTION
This pull request includes the addition of configuration files for different versions of the Doge model, specifically the 20M, 60M, 160M, and 320M variants. These configuration files include detailed settings for logging, model parameters, data training, and training procedures.

Configuration settings for different Doge models:

* [`recipes/doge/Doge-20M-MoE/config_full.yaml`](diffhunk://#diff-ad81bee04ddde979391a4dc998af9b2052f876068f98e1e1b5f97c62e36f44cbR1-R77): Added configuration for the 20M MoE model, including logging, model arguments, data training arguments, and PT trainer arguments.
* [`recipes/doge/Doge-120M-MoE/config_full.yaml`](diffhunk://#diff-2d6d5f91dc009e34da1e96f153198887b622dacb8d56c149bd8f50455b6532f6R1-R77): Added configuration for the 60M MoE model, including logging, model arguments, data training arguments, and PT trainer arguments.
* [`recipes/doge/Doge-480M-MoE/config_full.yaml`](diffhunk://#diff-2283c55459bbd1eb03c6ee0a3f5dd9b57e07719c69d0e36321dc28ac1e40ab46R1-R77): Added configuration for the 160M MoE model, including logging, model arguments, data training arguments, and PT trainer arguments.
* [`recipes/doge/Doge-1.4B-MoE/config_full.yaml`](diffhunk://#diff-ae1bea9a8c3c4fe5a6f08ee33df57e37ef7ea312b7ce2567504446e3b87fcac2R1-R77): Added configuration for the 320M MoE model, including logging, model arguments, data training arguments, and PT trainer arguments.