### PR TITLE
Reconstruct qk retrieval to router retrieval

### DIFF
--- a/recipes/doge/Doge-1.4B-MoE/config_full.yaml
+++ b/recipes/doge/Doge-1.4B-MoE/config_full.yaml
@@ -36,7 +36,6 @@ model_config:
   is_moe: True
   num_experts: 16384
   num_experts_per_tok: 64
-  expert_retrieval_size: 64
 
 model_name_or_path: SmallDoge/Doge-320M
 torch_dtype: bfloat16

--- a/recipes/doge/Doge-120M-MoE/config_full.yaml
+++ b/recipes/doge/Doge-120M-MoE/config_full.yaml
@@ -36,7 +36,6 @@ model_config:
   is_moe: True
   num_experts: 4096
   num_experts_per_tok: 32
-  expert_retrieval_size: 64
 
 model_name_or_path: SmallDoge/Doge-60M
 torch_dtype: bfloat16

--- a/recipes/doge/Doge-20M-MoE/config_full.yaml
+++ b/recipes/doge/Doge-20M-MoE/config_full.yaml
@@ -36,7 +36,6 @@ model_config:
   is_moe: True
   num_experts: 1024
   num_experts_per_tok: 16
-  expert_retrieval_size: 64
 
 model_name_or_path: SmallDoge/Doge-20M
 torch_dtype: bfloat16

--- a/recipes/doge/Doge-480M-MoE/config_full.yaml
+++ b/recipes/doge/Doge-480M-MoE/config_full.yaml
@@ -36,7 +36,6 @@ model_config:
   is_moe: True
   num_experts: 9216
   num_experts_per_tok: 48
-  expert_retrieval_size: 64
 
 model_name_or_path: SmallDoge/Doge-160M
 torch_dtype: bfloat16

--- a/src/small_doge/models/configuration_doge.py
+++ b/src/small_doge/models/configuration_doge.py
@@ -121,8 +121,6 @@ class DogeConfig(PretrainedConfig):
             Number of Experts for the Cross Domain Mixture of Experts.
         num_experts_per_tok (`int`, *optional*, defaults to 8):
             Number of selected experts to route per-token.
-        expert_retrieval_size (`int`, *optional*, defaults to 64):
-            Dimension of the Expert retrieval states for calculating the dot product of query and key to determine the expert index.
 
     ```python
     >>> from transformers import DogeConfig, DogeModel
@@ -149,7 +147,7 @@ class DogeConfig(PretrainedConfig):
         "layers.*.feed_forward.gate_proj": "colwise",
         "layers.*.feed_forward.up_proj": "colwise",
         "layers.*.feed_forward.down_proj": "rowwise",
-        "layers.*.feed_forward.queries_proj": "colwise",
+        "layers.*.feed_forward.router_gate": "colwise",
         "layers.*.feed_forward.down_embed": "rowwise",
         "layers.*.feed_forward.up_embed": "rowwise",
     }
@@ -181,7 +179,6 @@ class DogeConfig(PretrainedConfig):
         is_moe=False,
         num_experts=2048,
         num_experts_per_tok=8,
-        expert_retrieval_size=64,
         **kwargs,
     ):
         self.vocab_size = vocab_size
@@ -207,7 +204,6 @@ class DogeConfig(PretrainedConfig):
         self.is_moe = is_moe
         self.num_experts = num_experts
         self.num_experts_per_tok = num_experts_per_tok
-        self.expert_retrieval_size = expert_retrieval_size
 
         # Validate the correctness of rotary position embeddings parameters
         # BC: if there is a 'type' field, copy it it to 'rope_type'.

--- a/src/small_doge/models/modeling_doge.py
+++ b/src/small_doge/models/modeling_doge.py
@@ -480,14 +480,12 @@ class DogeCDMoE(DogeMLP):
         self.hidden_dim = config.hidden_size
         self.act_fn = ACT2FN[config.hidden_act]
 
-        self.expert_retrieval_dim = config.expert_retrieval_size
         self.num_experts = config.num_experts
         self.top_k = config.num_experts_per_tok
         self.num_keys = int(math.sqrt(self.num_experts))
 
-        # queries and keys for retrieval experts
-        self.queries_proj = nn.Linear(self.hidden_dim, self.expert_retrieval_dim, bias=False)
-        self.keys = nn.Parameter(torch.zeros(2, self.expert_retrieval_dim // 2, self.num_keys))
+        # router gate for retrieval experts
+        self.router_gate = nn.Linear(self.hidden_dim, self.num_keys * 2)
 
         # experts
         self.down_embed = nn.Embedding(self.num_experts, self.hidden_dim)
@@ -500,9 +498,8 @@ class DogeCDMoE(DogeMLP):
     ) -> torch.Tensor:
         bsz, seq_len, _ = hidden_states.shape
 
-        # get routing weights with queries and keys
-        queries = self.queries_proj(hidden_states).view(2, bsz * seq_len, -1)
-        routing_weights = torch.matmul(queries, self.keys)
+        # get routing weights with router gate
+        routing_weights = self.router_gate(hidden_states).view(2, bsz * seq_len, -1)
 
         # get experts with the highest routing weights
         (scores_x, scores_y), (indices_x, indices_y) = [w.topk(self.num_keys, dim=-1) for w in routing_weights]


### PR DESCRIPTION
This pull request includes several changes to the `DogeConfig` and `DogeModel` classes in the `small_doge` module, focusing on the removal of the `expert_retrieval_size` parameter and the replacement of the `queries_proj` and `keys` mechanism with a `router_gate` mechanism for routing experts.

Key changes include:

### Removal of `expert_retrieval_size`:

* [`src/small_doge/models/configuration_doge.py`](diffhunk://#diff-bf1b7412b5f22687f96f4b00d39a2ab3208e04b51dfd292e64b995858f541a26L124-L125): Removed the `expert_retrieval_size` parameter from the `DogeConfig` class and its usage in the `__init__` method. [[1]](diffhunk://#diff-bf1b7412b5f22687f96f4b00d39a2ab3208e04b51dfd292e64b995858f541a26L124-L125) [[2]](diffhunk://#diff-bf1b7412b5f22687f96f4b00d39a2ab3208e04b51dfd292e64b995858f541a26L184) [[3]](diffhunk://#diff-bf1b7412b5f22687f96f4b00d39a2ab3208e04b51dfd292e64b995858f541a26L210)
* [`src/small_doge/models/modular_doge.py`](diffhunk://#diff-c2a11bc00cd9856ee25a259b7cd0f7cd6a46dda84a29bbd3a7fb76cedf8beecbL164-L165): Removed the `expert_retrieval_size` parameter from the `DogeConfig` class and its usage in the `__init__` method. [[1]](diffhunk://#diff-c2a11bc00cd9856ee25a259b7cd0f7cd6a46dda84a29bbd3a7fb76cedf8beecbL164-L165) [[2]](diffhunk://#diff-c2a11bc00cd9856ee25a259b7cd0f7cd6a46dda84a29bbd3a7fb76cedf8beecbL221) [[3]](diffhunk://#diff-c2a11bc00cd9856ee25a259b7cd0f7cd6a46dda84a29bbd3a7fb76cedf8beecbL247)

### Replacement of `queries_proj` and `keys` with `router_gate`:

* [`src/small_doge/models/configuration_doge.py`](diffhunk://#diff-bf1b7412b5f22687f96f4b00d39a2ab3208e04b51dfd292e64b995858f541a26L152-R150): Updated the `feed_forward` layer configuration to use `router_gate` instead of `queries_proj`.
* [`src/small_doge/models/modeling_doge.py`](diffhunk://#diff-2dfe4091abce41550f065891428157efa3c1321e9dcf54751424eed4c9233446L483-R488): Replaced the `queries_proj` and `keys` mechanism with a `router_gate` mechanism in the `__init__` and `forward` methods. [[1]](diffhunk://#diff-2dfe4091abce41550f065891428157efa3c1321e9dcf54751424eed4c9233446L483-R488) [[2]](diffhunk://#diff-2dfe4091abce41550f065891428157efa3c1321e9dcf54751424eed4c9233446L503-R502)
* [`src/small_doge/models/modular_doge.py`](diffhunk://#diff-c2a11bc00cd9856ee25a259b7cd0f7cd6a46dda84a29bbd3a7fb76cedf8beecbR190-R192): Added `router_gate` to the `feed_forward` layer configuration and replaced the `queries_proj` and `keys` mechanism with a `router_gate` mechanism in the `__init__` and `forward` methods. [[1]](diffhunk://#diff-c2a11bc00cd9856ee25a259b7cd0f7cd6a46dda84a29bbd3a7fb76cedf8beecbR190-R192) [[2]](diffhunk://#diff-c2a11bc00cd9856ee25a259b7cd0f7cd6a46dda84a29bbd3a7fb76cedf8beecbL597-R597) [[3]](diffhunk://#diff-c2a11bc00cd9856ee25a259b7cd0f7cd6a46dda84a29bbd3a7fb76cedf8beecbL612-R619)