### PR TITLE
Fix nits

### DIFF
--- a/src/small_doge/models/modeling_doge.py
+++ b/src/small_doge/models/modeling_doge.py
@@ -485,7 +485,7 @@ class DogeCDMoE(DogeMLP):
         self.num_keys = int(math.sqrt(self.num_experts))
 
         # router gate for retrieval experts
-        self.router_gate = nn.Linear(self.hidden_dim, self.num_keys * 2)
+        self.router_gate = nn.Linear(self.hidden_dim, self.num_keys * 2, bias=False)
 
         # experts
         self.down_embed = nn.Embedding(self.num_experts, self.hidden_dim)

--- a/src/small_doge/models/modular_doge.py
+++ b/src/small_doge/models/modular_doge.py
@@ -588,13 +588,12 @@ class DogeCDMoE(DogeMLP):
         self.hidden_dim = config.hidden_size
         self.act_fn = ACT2FN[config.hidden_act]
 
-        self.expert_retrieval_dim = config.expert_retrieval_size
         self.num_experts = config.num_experts
         self.top_k = config.num_experts_per_tok
         self.num_keys = int(math.sqrt(self.num_experts))
 
         # router gate for retrieval experts
-        self.router_gate = nn.Linear(self.hidden_dim, self.num_keys * 2)
+        self.router_gate = nn.Linear(self.hidden_dim, self.num_keys * 2, bias=False)
 
         # experts
         self.down_embed = nn.Embedding(self.num_experts, self.hidden_dim)


### PR DESCRIPTION
This pull request includes changes to the initialization methods in two different files to modify the `router_gate` layer by removing the bias term. This change ensures that the `nn.Linear` layer in both `modeling_doge.py` and `modular_doge.py` is created without a bias parameter.

Changes to `router_gate` initialization:

* [`src/small_doge/models/modeling_doge.py`](diffhunk://#diff-2dfe4091abce41550f065891428157efa3c1321e9dcf54751424eed4c9233446L488-R488): Modified the `router_gate` layer in the `__init__` method to remove the bias term.
* [`src/small_doge/models/modular_doge.py`](diffhunk://#diff-c2a11bc00cd9856ee25a259b7cd0f7cd6a46dda84a29bbd3a7fb76cedf8beecbL591-R596): Modified the `router_gate` layer in the `__init__` method to remove the bias term.