### PR TITLE
Add more accelerate configs for training

### DIFF
--- a/recipes/accelerate_configs/fsdp.yaml
+++ b/recipes/accelerate_configs/fsdp.yaml
@@ -1,0 +1,27 @@
+compute_environment: LOCAL_MACHINE
+debug: false
+distributed_type: FSDP
+downcast_bf16: 'no'
+enable_cpu_affinity: false
+fsdp_config:
+  fsdp_activation_checkpointing: false # Need fix from: https://github.com/huggingface/transformers/pull/36610
+  fsdp_auto_wrap_policy: TRANSFORMER_BASED_WRAP
+  fsdp_backward_prefetch: BACKWARD_PRE
+  fsdp_cpu_ram_efficient_loading: true
+  fsdp_forward_prefetch: true
+  fsdp_offload_params: false
+  fsdp_sharding_strategy: FULL_SHARD
+  fsdp_state_dict_type: FULL_STATE_DICT
+  fsdp_sync_module_states: true
+  fsdp_use_orig_params: true
+machine_rank: 0
+main_training_function: main
+mixed_precision: bf16
+num_machines: 1
+num_processes: 8
+rdzv_backend: static
+same_network: true
+tpu_env: []
+tpu_use_cluster: false
+tpu_use_sudo: false
+use_cpu: false

--- a/recipes/accelerate_configs/zero0.yaml
+++ b/recipes/accelerate_configs/zero0.yaml
@@ -1,0 +1,21 @@
+compute_environment: LOCAL_MACHINE
+debug: false
+deepspeed_config:
+  deepspeed_multinode_launcher: standard
+  offload_optimizer_device: none
+  offload_param_device: none
+  zero3_init_flag: false
+  zero_stage: 0
+distributed_type: DEEPSPEED
+downcast_bf16: 'no'
+machine_rank: 0
+main_training_function: main
+mixed_precision: bf16
+num_machines: 1
+num_processes: 8
+rdzv_backend: static
+same_network: true
+tpu_env: []
+tpu_use_cluster: false
+tpu_use_sudo: false
+use_cpu: false

--- a/recipes/accelerate_configs/zero1.yaml
+++ b/recipes/accelerate_configs/zero1.yaml
@@ -1,0 +1,21 @@
+compute_environment: LOCAL_MACHINE
+debug: false
+deepspeed_config:
+  deepspeed_multinode_launcher: standard
+  offload_optimizer_device: none
+  offload_param_device: none
+  zero3_init_flag: false
+  zero_stage: 1
+distributed_type: DEEPSPEED
+downcast_bf16: 'no'
+machine_rank: 0
+main_training_function: main
+mixed_precision: bf16
+num_machines: 1
+num_processes: 8
+rdzv_backend: static
+same_network: true
+tpu_env: []
+tpu_use_cluster: false
+tpu_use_sudo: false
+use_cpu: false


### PR DESCRIPTION
This pull request includes the addition of new configuration files for different distributed training setups. The configurations are tailored for specific environments and training strategies, such as Fully Sharded Data Parallel (FSDP) and DeepSpeed with different Zero Redundancy Optimizer (ZeRO) stages.

New configuration files added:

* [`recipes/accelerate_configs/fsdp.yaml`](diffhunk://#diff-1823b83df74855c61b6869ec0b046370e4959bce745fb601f28598a7e409f589R1-R27): Configuration for Fully Sharded Data Parallel (FSDP) setup, including settings for activation checkpointing, sharding strategy, and mixed precision.
* [`recipes/accelerate_configs/zero0.yaml`](diffhunk://#diff-23c156bd4af610289214d69cc77b22c6ef767b397d824e154cdcb9d5f8199f96R1-R21): Configuration for DeepSpeed with Zero Redundancy Optimizer (ZeRO) stage 0, including settings for optimizer and parameter offloading, and mixed precision.
* [`recipes/accelerate_configs/zero1.yaml`](diffhunk://#diff-e219e87e578d545c88c4a4775774f14765f8f18c5e0ae1003bae0a8c390d2029R1-R21): Configuration for DeepSpeed with Zero Redundancy Optimizer (ZeRO) stage 1, including settings for optimizer and parameter offloading, and mixed precision.