### PR TITLE
Fix hub id

### DIFF
--- a/recipes/doge/Doge-1.4B-MoE/config_full.yaml
+++ b/recipes/doge/Doge-1.4B-MoE/config_full.yaml
@@ -7,12 +7,12 @@ report_to:
 - wandb
 save_strategy: steps
 save_steps: 100
-output_dir: data/Doge-320M-MoE
+output_dir: data/Doge-1.4B-MoE
 overwrite_output_dir: true
 push_to_hub: true
 private: true
 # token: <your-token>
-hub_model_id: Doge-320M-MoE
+hub_model_id: Doge-1.4B-MoE
 hub_strategy: every_save
 
 # Model arguments

--- a/recipes/doge/Doge-120M-MoE/config_full.yaml
+++ b/recipes/doge/Doge-120M-MoE/config_full.yaml
@@ -7,12 +7,12 @@ report_to:
 - wandb
 save_strategy: steps
 save_steps: 100
-output_dir: data/Doge-60M-MoE
+output_dir: data/Doge-120M-MoE
 overwrite_output_dir: true
 push_to_hub: true
 private: true
 # token: <your-token>
-hub_model_id: Doge-60M-MoE
+hub_model_id: Doge-120M-MoE
 hub_strategy: every_save
 
 # Model arguments

--- a/recipes/doge/Doge-480M-MoE/config_full.yaml
+++ b/recipes/doge/Doge-480M-MoE/config_full.yaml
@@ -7,12 +7,12 @@ report_to:
 - wandb
 save_strategy: steps
 save_steps: 100
-output_dir: data/Doge-160M-MoE
+output_dir: data/Doge-480M-MoE
 overwrite_output_dir: true
 push_to_hub: true
 private: true
 # token: <your-token>
-hub_model_id: Doge-160M-MoE
+hub_model_id: Doge-480M-MoE
 hub_strategy: every_save
 
 # Model arguments


### PR DESCRIPTION
This pull request includes updates to the configuration files for different versions of the Doge model in the `recipes/doge` directory. The changes primarily involve updating the `output_dir` and `hub_model_id` to reflect the correct model sizes.

Configuration updates for Doge models:

* [`recipes/doge/Doge-1.4B-MoE/config_full.yaml`](diffhunk://#diff-ae1bea9a8c3c4fe5a6f08ee33df57e37ef7ea312b7ce2567504446e3b87fcac2L10-R15): Updated `output_dir` to `data/Doge-1.4B-MoE` and `hub_model_id` to `Doge-1.4B-MoE` to match the 1.4B model size.
* [`recipes/doge/Doge-120M-MoE/config_full.yaml`](diffhunk://#diff-2d6d5f91dc009e34da1e96f153198887b622dacb8d56c149bd8f50455b6532f6L10-R15): Updated `output_dir` to `data/Doge-120M-MoE` and `hub_model_id` to `Doge-120M-MoE` to match the 120M model size.
* [`recipes/doge/Doge-480M-MoE/config_full.yaml`](diffhunk://#diff-2283c55459bbd1eb03c6ee0a3f5dd9b57e07719c69d0e36321dc28ac1e40ab46L10-R15): Updated `output_dir` to `data/Doge-480M-MoE` and `hub_model_id` to `Doge-480M-MoE` to match the 480M model size.