### PR TITLE
Add Doge-120M-MoE-Instruct recipes

### DIFF
--- a/recipes/doge/Doge-120M-MoE-Instruct/dpo/config_full.yaml
+++ b/recipes/doge/Doge-120M-MoE-Instruct/dpo/config_full.yaml
@@ -1,0 +1,53 @@
+# Logging and Output arguments
+log_level: info
+logging_strategy: steps
+logging_steps: 100
+report_to:
+- tensorboard
+- wandb
+save_strategy: steps
+save_steps: 100
+output_dir: data/Doge-120M-MoE-Instruct-DPO
+overwrite_output_dir: true
+push_to_hub: true
+private: true
+# token: <your-token>
+hub_model_id: Doge-120M-MoE-Instruct-DPO
+hub_strategy: every_save
+
+# Model arguments
+model_name_or_path: SmallDoge/Doge-120M-MoE-Instruct-SFT
+model_revision: main
+trust_remote_code: True
+torch_dtype: bfloat16
+
+# Data training arguments
+dataset_name: ./datasets/dpo_dataset
+dataset_configs:
+- all
+max_length: 1024
+max_prompt_length: 512
+
+# DPO Trainer arguments
+preprocessing_num_workers: 1 # Equal to the number of GPUs you are using
+seed: 233
+do_train: True
+num_train_epochs: 2
+per_device_train_batch_size: 1
+do_eval: True
+eval_strategy: steps
+eval_steps: 100
+per_device_eval_batch_size: 1
+optim: adamw_torch
+learning_rate: 6.0e-5
+lr_scheduler_type: cosine_with_min_lr
+lr_scheduler_kwargs:
+  min_lr_rate: 0.1
+warmup_ratio: 0.1
+weight_decay: 0.01
+gradient_accumulation_steps: 128
+gradient_checkpointing: true
+gradient_checkpointing_kwargs:
+  use_reentrant: false
+max_grad_norm: 1.0
+bf16: True

--- a/recipes/doge/Doge-120M-MoE-Instruct/sft/config_full.yaml
+++ b/recipes/doge/Doge-120M-MoE-Instruct/sft/config_full.yaml
@@ -1,0 +1,53 @@
+# Logging and Output arguments
+log_level: info
+logging_strategy: steps
+logging_steps: 100
+report_to:
+- tensorboard
+- wandb
+save_strategy: steps
+save_steps: 100
+output_dir: data/Doge-120M-MoE-Instruct-SFT
+overwrite_output_dir: true
+push_to_hub: true
+private: true
+# token: <your-token>
+hub_model_id: Doge-120M-MoE-Instruct-SFT
+hub_strategy: every_save
+
+# Model arguments
+model_name_or_path: SmallDoge/Doge-120M-MoE
+model_revision: main
+trust_remote_code: True
+torch_dtype: bfloat16
+
+# Data training arguments
+dataset_name: ./datasets/sft_dataset
+dataset_configs:
+- all
+max_seq_length: 2048
+packing: True
+
+# SFT trainer arguments
+preprocessing_num_workers: 1 # Equal to the number of GPUs you are using
+seed: 233
+do_train: True
+num_train_epochs: 2
+per_device_train_batch_size: 1
+do_eval: True
+eval_strategy: steps
+eval_steps: 100
+per_device_eval_batch_size: 1
+optim: adamw_torch
+learning_rate: 6.0e-4
+lr_scheduler_type: cosine_with_min_lr
+lr_scheduler_kwargs:
+  min_lr_rate: 0.1
+warmup_ratio: 0.1
+weight_decay: 0.01
+gradient_accumulation_steps: 128
+gradient_checkpointing: true
+gradient_checkpointing_kwargs:
+  use_reentrant: false
+max_grad_norm: 1.0
+bf16: True


### PR DESCRIPTION
This pull request includes configuration updates for the Doge-120M-MoE-Instruct model, specifically for the DPO and SFT training processes. The changes introduce new logging, model, data training, and trainer arguments to enhance the training and evaluation workflows.

Logging and Output arguments:

* Added logging configurations, including log level, logging strategy, and logging steps. Configurations for reporting to `tensorboard` and `wandb` were also added. [[1]](diffhunk://#diff-f577599c3c00892d5dd73a076d216d4d86945a26d9cd0d5aae932eee1b684e8eR1-R53) [[2]](diffhunk://#diff-b46482ef66e5c6cdd009b515f4a4d648a17506925c0a7e20abeb861e31825cd4R1-R53)
* Introduced save strategy and steps, output directory settings, and hub-related configurations such as `push_to_hub` and `hub_model_id`. [[1]](diffhunk://#diff-f577599c3c00892d5dd73a076d216d4d86945a26d9cd0d5aae932eee1b684e8eR1-R53) [[2]](diffhunk://#diff-b46482ef66e5c6cdd009b515f4a4d648a17506925c0a7e20abeb861e31825cd4R1-R53)

Model arguments:

* Configured model parameters such as `model_name_or_path`, `model_revision`, `trust_remote_code`, and `torch_dtype`. [[1]](diffhunk://#diff-f577599c3c00892d5dd73a076d216d4d86945a26d9cd0d5aae932eee1b684e8eR1-R53) [[2]](diffhunk://#diff-b46482ef66e5c6cdd009b515f4a4d648a17506925c0a7e20abeb861e31825cd4R1-R53)

Data training arguments:

* Added dataset configurations, including `dataset_name` and specific dataset settings like `max_length` and `max_prompt_length` for DPO, and `max_seq_length` and `packing` for SFT. [[1]](diffhunk://#diff-f577599c3c00892d5dd73a076d216d4d86945a26d9cd0d5aae932eee1b684e8eR1-R53) [[2]](diffhunk://#diff-b46482ef66e5c6cdd009b515f4a4d648a17506925c0a7e20abeb861e31825cd4R1-R53)

Trainer arguments:

* Defined various trainer settings such as `num_train_epochs`, batch sizes, optimizer type, learning rate, scheduler type, warmup ratio, weight decay, and gradient accumulation steps. [[1]](diffhunk://#diff-f577599c3c00892d5dd73a076d216d4d86945a26d9cd0d5aae932eee1b684e8eR1-R53) [[2]](diffhunk://#diff-b46482ef66e5c6cdd009b515f4a4d648a17506925c0a7e20abeb861e31825cd4R1-R53)
* Enabled gradient checkpointing with specific configurations and set `max_grad_norm` and `bf16` for both DPO and SFT trainers. [[1]](diffhunk://#diff-f577599c3c00892d5dd73a076d216d4d86945a26d9cd0d5aae932eee1b684e8eR1-R53) [[2]](diffhunk://#diff-b46482ef66e5c6cdd009b515f4a4d648a17506925c0a7e20abeb861e31825cd4R1-R53)