### PR TITLE
Add chat template

### DIFF
--- a/evaluation/eval_downstream_tasks.ps1
+++ b/evaluation/eval_downstream_tasks.ps1
@@ -8,12 +8,14 @@ if ($MODEL -match "Instruct$") {
     "evaluation/instruct/doge_instruct.txt" `
     --custom-tasks evaluation/instruct/tasks.py `
     --override-batch-size 1 `
+    --use-chat-template `
     --output-dir $OUTPUT_DIR
 } elseif ($MODEL -match "Reason$") {
     lighteval vllm $MODEL_ARGS `
     "evaluation/reason/doge_reason.txt" `
     --custom-tasks evaluation/reason/tasks.py `
     --override-batch-size 1 `
+    --use-chat-template `
     --output-dir $OUTPUT_DIR
 }
 else {

--- a/evaluation/eval_downstream_tasks.sh
+++ b/evaluation/eval_downstream_tasks.sh
@@ -9,12 +9,14 @@ if [[ $MODEL =~ Instruct$ ]]; then
     "evaluation/instruct/doge_instruct.txt" \
     --custom-tasks evaluation/instruct/tasks.py \
     --override-batch-size 1 \
+    --use-chat-template \
     --output-dir $OUTPUT_DIR
 elif [[ $MODEL =~ Reason$ ]]; then
     lighteval vllm $MODEL_ARGS \
     "evaluation/reason/doge_reason.txt" \
     --custom-tasks evaluation/reason/tasks.py \
     --override-batch-size 1 \
+    --use-chat-template \
     --output-dir $OUTPUT_DIR
 else
     lighteval accelerate $MODEL_ARGS \


### PR DESCRIPTION
This pull request introduces a small but significant change to the evaluation scripts for downstream tasks. The `--use-chat-template` flag has been added to both PowerShell and Bash evaluation scripts to enable the use of chat templates during the evaluation process.

Changes to evaluation scripts:

* [`evaluation/eval_downstream_tasks.ps1`](diffhunk://#diff-c8f9721d2f9c8880ce391ffa2283af73444b73a0e652ee21aab3c6f0ebbc0fb9R11-R18): Added the `--use-chat-template` flag to the evaluation commands for models matching "Instruct$" and "Reason$".
* [`evaluation/eval_downstream_tasks.sh`](diffhunk://#diff-bc5777a9b77db514f9baad35aa8f64b37b1d2cc267b8231c114fa39cabdd00eeR12-R19): Added the `--use-chat-template` flag to the evaluation commands for models matching "Instruct$" and "Reason$".