### PR TITLE
Add assert

### DIFF
--- a/src/small_doge/processor/pt_datasets_process.py
+++ b/src/small_doge/processor/pt_datasets_process.py
@@ -177,6 +177,11 @@ def mix_datasets_by_ratio(
         print(mixed_dataset)
     ```"""
 
+    # Check if the dataset ratios sum to 1.0
+    total_ratio = sum([list(dataset.values())[0] for dataset in datasets_and_ratios])
+    if total_ratio != 1.0:
+        raise ValueError(f"Total ratio must be 1.0, but got {total_ratio}. Please check your ratios.")
+
     final_mixed_dataset = {}
 
     for dataset_and_ratio in datasets_and_ratios:


### PR DESCRIPTION
This pull request introduces a validation step in the `mix_datasets_by_ratio` function to ensure that the provided dataset ratios sum to 1.0. This change improves the robustness of the function by preventing incorrect ratio configurations.

Validation added to dataset mixing:

* [`src/small_doge/processor/pt_datasets_process.py`](diffhunk://#diff-9878d1df90499f82ed03599584c2f21fc54f6c2f9afbaf25f1f0cc716c3633a0R180-R184): Added a check to verify that the sum of dataset ratios equals 1.0, raising a `ValueError` if the condition is not met.