### PR TITLE
Fix some nits

### DIFF
--- a/src/small_doge/processor/pt_datasets_process.py
+++ b/src/small_doge/processor/pt_datasets_process.py
@@ -188,7 +188,9 @@ def mix_datasets_by_ratio(
         dataset_name, ratio = dataset_and_ratio.popitem()
 
         # Check subset name
-        if ":" in dataset_name:
+        windows_drive_pattern = r'^[a-zA-Z]:.*'
+        is_windows_path = bool(re.match(windows_drive_pattern, dataset_name))
+        if ":" in dataset_name and not is_windows_path:
             dataset_name, subset_name = dataset_name.split(":")
         else:
             subset_name = None
@@ -208,9 +210,10 @@ def mix_datasets_by_ratio(
         # Process each split of the dataset
         for split_name, split_dataset in dataset.items():
 
+            logger.info(f"Original dataset size for {dataset_name}: {split_name}: {len(split_dataset)}")
             # Process the dataset from text to input_ids
             split_dataset = prepare_dataset(
-                split_dataset.take(100),
+                split_dataset,
                 dataset_name=f"{dataset_name}: {split_name}" if subset_name is None else f"{dataset_name}: {subset_name}: {split_name}",
                 dataset_text_field=dataset_text_field,
                 processing_class=processing_class,
@@ -219,13 +222,20 @@ def mix_datasets_by_ratio(
                 formatting_func=formatting_func,
                 dataset_num_proc=dataset_num_proc,
             )
+            
 
             # Calculate the target size for the dataset
             target_size = int(total_sample_size * ratio) if split_name == "train" else len(split_dataset)
             current_size = len(split_dataset)
+            logger.info(f"Processed dataset size for {dataset_name}: {split_name}: {current_size}")
+            logger.info(f"Target size for {dataset_name}: {split_name}: {target_size}")
 
             # If the dataset is smaller than the target size, repeat it
             if current_size < target_size:
+                logger.warning(
+                    f"Dataset {dataset_name}: {split_name} is smaller than the target size. "
+                    f"Repeating the dataset to reach the target size."
+                )
                 indices = []
                 full_copies = target_size // current_size
                 remainder = target_size % current_size
@@ -237,6 +247,10 @@ def mix_datasets_by_ratio(
                 
                 split_dataset = split_dataset.select(indices)
             else:
+                logger.warning(
+                    f"Dataset {dataset_name}: {split_name} is larger than the target size. "
+                    f"Truncating the dataset to reach the target size."
+                )
                 split_dataset = split_dataset.select(range(target_size))
             
             # Concatenate the split dataset with the final mixed dataset

--- a/src/small_doge/processor/pt_datasets_process.py
+++ b/src/small_doge/processor/pt_datasets_process.py
@@ -162,7 +162,7 @@ def mix_datasets_by_ratio(
         tokenizer = AutoTokenizer.from_pretrained("SmallDoge/Doge-tokenizer")
     
         # Mix datasets
-        mixed_dataset = mix_datasets_by_radio(
+        mixed_dataset = mix_datasets_by_ratio(
             datasets_and_ratios=datasets_and_ratios,
             total_sample_size=10000,
             dataset_text_field="text",


### PR DESCRIPTION
This pull request refines the `mix_datasets_by_ratio` function in `src/small_doge/processor/pt_datasets_process.py` by fixing a typo, improving dataset handling for Windows paths, and adding detailed logging for dataset processing. These changes enhance code correctness, compatibility, and debuggability.

### Fixes and corrections:
* Corrected a typo in the function call from `mix_datasets_by_radio` to `mix_datasets_by_ratio`, ensuring the correct function is invoked.

### Compatibility improvements:
* Updated the logic for handling dataset names with colons (`:`) to account for Windows file paths, preventing incorrect splitting of paths.

### Logging enhancements:
* Added logging to display the original and processed dataset sizes for each split, as well as the target size for sampling. [[1]](diffhunk://#diff-9878d1df90499f82ed03599584c2f21fc54f6c2f9afbaf25f1f0cc716c3633a0R213-R216) [[2]](diffhunk://#diff-9878d1df90499f82ed03599584c2f21fc54f6c2f9afbaf25f1f0cc716c3633a0R226-R238)
* Included warnings for cases where datasets are smaller or larger than the target size, indicating when datasets are being repeated or truncated. [[1]](diffhunk://#diff-9878d1df90499f82ed03599584c2f21fc54f6c2f9afbaf25f1f0cc716c3633a0R226-R238) [[2]](diffhunk://#diff-9878d1df90499f82ed03599584c2f21fc54f6c2f9afbaf25f1f0cc716c3633a0R250-R253)