### PR TITLE
Add Doge2-175M recipe

### DIFF
--- a/recipes/doge2/Doge2-175M/config_full.yaml
+++ b/recipes/doge2/Doge2-175M/config_full.yaml
@@ -1,0 +1,72 @@
+# Logging and Output arguments
+log_level: info
+logging_strategy: steps
+logging_steps: 100
+report_to:
+- tensorboard
+- wandb
+save_strategy: steps
+save_steps: 100
+output_dir: data/Doge2-175M
+overwrite_output_dir: true
+push_to_hub: true
+private: true
+# token: <your-token>
+hub_model_id: Doge2-175M
+hub_strategy: every_save
+
+# Model arguments
+model_config:
+  vocab_size: 32768
+  hidden_size: 576
+  intermediate_size: 1536
+  num_hidden_layers: 30
+  hidden_dropout: 0.0
+  hidden_act: "silu"
+  use_cache: True
+  tie_word_embeddings: True
+  max_position_embeddings: 2048
+  rope_theta: 10000.0
+  num_attention_heads: 9
+  num_key_value_heads: 3
+  is_moe: True
+  num_experts: 900
+  num_experts_per_tok: 30
+  output_router_logits: True
+
+model_name_or_path: SmallDoge/Doge2-tokenizer
+torch_dtype: bfloat16
+
+# Data training arguments
+dataset_name: ./datasets/pt_dataset
+dataset_config: default
+
+# PT trainer arguments
+preprocessing_num_workers: 1 # Equal to the number of GPUs you are using
+seed: 233
+do_train: True
+max_steps: 60000
+per_device_train_batch_size: 1
+do_eval: True
+eval_strategy: steps
+eval_steps: 100
+per_device_eval_batch_size: 1
+optim: adamw_torch_fused
+adam_beta1: 0.9
+adam_beta2: 0.95
+adam_epsilon: 1.0e-8
+learning_rate: 4.0e-3
+lr_scheduler_type: warmup_stable_decay
+lr_scheduler_kwargs:
+  warmup_type: linear
+  decay_type: linear
+  num_decay_steps: 12000
+  min_lr_ratio: 0.0
+warmup_steps: 2000
+weight_decay: 0.01
+gradient_accumulation_steps: 256
+gradient_checkpointing: false
+gradient_checkpointing_kwargs:
+  use_reentrant: false
+max_grad_norm: 1.0
+bf16: True

--- a/src/small_doge/trainer/doge/dpo.py
+++ b/src/small_doge/trainer/doge/dpo.py
@@ -26,7 +26,7 @@ from datasets import load_dataset, load_from_disk
 from transformers import AutoConfig, AutoModel, AutoModelForCausalLM, AutoTokenizer, set_seed
 from transformers.trainer_utils import get_last_checkpoint
 
-from small_doge.models import DogeConfig, DogeForCausalLM, DogeModel
+from small_doge.models.doge.modeling_doge import DogeConfig, DogeForCausalLM, DogeModel
 import trl
 from trl import (
     ModelConfig,

--- a/src/small_doge/trainer/doge/grpo.py
+++ b/src/small_doge/trainer/doge/grpo.py
@@ -29,7 +29,7 @@ from transformers.trainer_utils import get_last_checkpoint
 
 from latex2sympy2_extended import NormalizationConfig
 from math_verify import LatexExtractionConfig, parse, verify
-from small_doge.models import DogeConfig, DogeForCausalLM, DogeModel
+from small_doge.models.doge.modeling_doge import DogeConfig, DogeForCausalLM, DogeModel
 import trl
 from trl import (
     ModelConfig,

--- a/src/small_doge/trainer/doge/pt.py
+++ b/src/small_doge/trainer/doge/pt.py
@@ -38,7 +38,7 @@ from transformers import (
 from transformers.trainer_utils import get_last_checkpoint
 
 import yaml
-from small_doge.models.modeling_doge import DogeConfig, DogeForCausalLM, DogeModel
+from small_doge.models.doge.modeling_doge import DogeConfig, DogeForCausalLM, DogeModel
 from trl import ModelConfig, ScriptArguments, TrlParser
 
 

--- a/src/small_doge/trainer/doge/sft.py
+++ b/src/small_doge/trainer/doge/sft.py
@@ -26,7 +26,7 @@ from datasets import load_dataset, load_from_disk
 from transformers import AutoConfig, AutoModel, AutoModelForCausalLM, AutoTokenizer, set_seed
 from transformers.trainer_utils import get_last_checkpoint
 
-from small_doge.models import DogeConfig, DogeForCausalLM, DogeModel
+from small_doge.models.doge.modeling_doge import DogeConfig, DogeForCausalLM, DogeModel
 import trl
 from trl import (
     ModelConfig,

--- a/src/small_doge/trainer/doge2/dpo.py
+++ b/src/small_doge/trainer/doge2/dpo.py
@@ -26,7 +26,7 @@ from datasets import load_dataset, load_from_disk
 from transformers import AutoConfig, AutoModel, AutoModelForCausalLM, AutoTokenizer, set_seed
 from transformers.trainer_utils import get_last_checkpoint
 
-from small_doge.models import Doge2Config, Doge2ForCausalLM, Doge2Model
+from small_doge.models.doge2.modeling_doge2 import Doge2Config, Doge2ForCausalLM, Doge2Model
 import trl
 from trl import (
     ModelConfig,

--- a/src/small_doge/trainer/doge2/grpo.py
+++ b/src/small_doge/trainer/doge2/grpo.py
@@ -29,7 +29,7 @@ from transformers.trainer_utils import get_last_checkpoint
 
 from latex2sympy2_extended import NormalizationConfig
 from math_verify import LatexExtractionConfig, parse, verify
-from small_doge.models import Doge2Config, Doge2ForCausalLM, Doge2Model
+from small_doge.models.doge2.modeling_doge2 import Doge2Config, Doge2ForCausalLM, Doge2Model
 import trl
 from trl import (
     ModelConfig,

--- a/src/small_doge/trainer/doge2/sft.py
+++ b/src/small_doge/trainer/doge2/sft.py
@@ -26,7 +26,7 @@ from datasets import load_dataset, load_from_disk
 from transformers import AutoConfig, AutoModel, AutoModelForCausalLM, AutoTokenizer, set_seed
 from transformers.trainer_utils import get_last_checkpoint
 
-from small_doge.models import Doge2Config, Doge2ForCausalLM, Doge2Model
+from small_doge.models.doge2.modeling_doge2 import Doge2Config, Doge2ForCausalLM, Doge2Model
 import trl
 from trl import (
     ModelConfig,


### PR DESCRIPTION
This pull request introduces a new configuration file for the Doge2-175M model and refactors import paths across several training scripts to improve modularity and maintainability. Below is a breakdown of the most important changes:

### New Configuration for Doge2-175M Model:
* Added a comprehensive configuration file `recipes/doge2/Doge2-175M/config_full.yaml` for the Doge2-175M model, specifying logging, model, data training, and trainer arguments. This includes parameters like `vocab_size`, `num_hidden_layers`, `learning_rate`, and `gradient_accumulation_steps`.

### Refactored Import Paths:
* Updated import paths in `src/small_doge/trainer/doge` scripts (`dpo.py`, `grpo.py`, `pt.py`, `sft.py`) to use `small_doge.models.doge.modeling_doge` instead of the generic `small_doge.models` module. This change improves clarity and aligns with the modular structure. [[1]](diffhunk://#diff-077ed57649860d5ab4be28d5e0993859c7d987a744641aff9acf998cbea09a1fL29-R29) [[2]](diffhunk://#diff-684b170e89b843c2f4e2d4506ec31c4d59e73af1258132d66f0617947427979bL32-R32) [[3]](diffhunk://#diff-60e11856443d79259defde7f6ec05dccb80a3f010f9fe2a23a5879f09e5e3ed2L41-R41) [[4]](diffhunk://#diff-f72447d84ff1db6dde08b4514c58eb86c2649b0a112b87ec09b4c13fd1df31e5L29-R29)
* Updated import paths in `src/small_doge/trainer/doge2` scripts (`dpo.py`, `grpo.py`, `sft.py`) to use `small_doge.models.doge2.modeling_doge2` instead of the generic `small_doge.models` module. This ensures consistency with the Doge2-specific model implementation. [[1]](diffhunk://#diff-e27478dd70bdd7ee3349a55bf4a528602c6f5784cd000196837f49ec46e7301aL29-R29) [[2]](diffhunk://#diff-2d745ea1acaa1a5ed6d41a425b549aabe3ebf9dcff0264a7604d880c2464a202L32-R32) [[3]](diffhunk://#diff-357db68f8a035d8dc05be2e021bf2996b85614b5c4d07955e9a0c67037b581f2L29-R29)