### PR TITLE
Update `set_warmup_phase`

### DIFF
--- a/src/small_doge/trainer/doge2/pt.py
+++ b/src/small_doge/trainer/doge2/pt.py
@@ -82,19 +82,20 @@ def set_warmup_phase(model: Doge2ForCausalLM, phase: int):
     # Thaw the corresponding parameters according to the current phase
     unfreeze_params = []
     phase_name = ""
+    active_params = []
 
     if phase == 1:
         # Phase 1: Only train self-attention-related parameters
         active_params = attn_params
         phase_name = "Self-Attention"
     elif phase == 2:
-        # Phase 2: Only train MLP-related parameters
-        active_params = mlp_params
-        phase_name = "MLP"
+        # Phase 2: Train self-attention + MLP parameters
+        active_params = attn_params + mlp_params
+        phase_name = "Self-Attention + MLP"
     elif phase == 3:
-        # Phase 3: Train residual connection related parameters
-        active_params = residual_params
-        phase_name = "Residual"
+        # Phase 3: Train self-attention + MLP + residual parameters
+        active_params = attn_params + mlp_params + residual_params
+        phase_name = "Self-Attention + MLP + Residual"
     elif phase == 4:
         # Phase 4: Train all parameters together
         active_params = all_params
@@ -154,7 +155,7 @@ class MultiphaseWarmupCallback(TrainerCallback):
 
         # If the phase has changed, update model parameters
         if determined_phase != self.current_phase:
-            phase_names = ["Self-Attention", "MLP", "Residual", "All Parameters"]
+            phase_names = ["Self-Attention", "Self-Attention + MLP", "Self-Attention + MLP + Residual", "All Parameters"]
             logger.info(f"Transitioning from warm-up phase {self.current_phase}: {phase_names[self.current_phase-1]} "
                        f"to phase {determined_phase}: {phase_names[determined_phase-1]} at step {current_step}")
             


### PR DESCRIPTION
This pull request updates the warm-up phase logic in the `Doge2` trainer to allow for more comprehensive parameter training at each phase. The changes primarily involve modifying the parameters trained in each phase and updating the corresponding phase names to reflect these adjustments.

### Updates to warm-up phase logic:

* [`src/small_doge/trainer/doge2/pt.py`](diffhunk://#diff-2fc8856133d98e8d4bda2c0f521e8f271034f9e107a10e433b907e5addfc2e5aR85-R98): Adjusted the parameters trained in phases 2 and 3 to include combinations of self-attention, MLP, and residual parameters, instead of training them in isolation. This ensures a more integrated training approach.

* [`src/small_doge/trainer/doge2/pt.py`](diffhunk://#diff-2fc8856133d98e8d4bda2c0f521e8f271034f9e107a10e433b907e5addfc2e5aL157-R158): Updated the `phase_names` list to match the new phase descriptions, ensuring that logging messages accurately reflect the updated training phases.