### PR TITLE
Update `set_warmup_phase`

### DIFF
--- a/src/small_doge/trainer/doge2/pt.py
+++ b/src/small_doge/trainer/doge2/pt.py
@@ -51,7 +51,7 @@ def set_warmup_phase(model: Doge2ForCausalLM, phase: int):
     
     Args:
         model: The model
-        phase: Warm-up phase(1: Self-Attention, 2: MLP, 3: Residual, 4: All Parameters)
+        phase: Warm-up phase(1: Self-Attention, 2: Self-Attention+MLP, 3: Self-Attention+MLP+Residual, 4: All Parameters)
     
     Returns:
         model: The model with frozen/unfrozen parameters


### PR DESCRIPTION
This pull request updates the documentation for the `set_warmup_phase` function to clarify the phases of the warm-up process.

* Documentation update:
  * [`src/small_doge/trainer/doge2/pt.py`](diffhunk://#diff-2fc8856133d98e8d4bda2c0f521e8f271034f9e107a10e433b907e5addfc2e5aL54-R54): Updated the description of the `phase` argument to more accurately reflect the combination of components unfrozen at each phase.