### PR TITLE
Fix bug of tokenizer loading

### DIFF
--- a/src/small_doge/trainer/doge2/dpo.py
+++ b/src/small_doge/trainer/doge2/dpo.py
@@ -115,7 +115,10 @@ def main(
     # Load tokenizer
     ################
     tokenizer = AutoTokenizer.from_pretrained(
-        model_args.model_name_or_path, trust_remote_code=model_args.trust_remote_code, use_fast=True
+        model_args.model_name_or_path,
+        revision=model_args.model_revision,
+        use_fast=True,
+        trust_remote_code=model_args.trust_remote_code,
     )
     tokenizer.padding_side = "left"
     if tokenizer.pad_token is None:

--- a/src/small_doge/trainer/doge2/grpo.py
+++ b/src/small_doge/trainer/doge2/grpo.py
@@ -446,6 +446,19 @@ def main(
     else:
         dataset = load_from_disk(script_args.dataset_name)
 
+    ################
+    # Load tokenizer
+    ################
+    tokenizer = AutoTokenizer.from_pretrained(
+        model_args.model_name_or_path,
+        revision=model_args.model_revision,
+        use_fast=True,
+        trust_remote_code=model_args.trust_remote_code,
+    )
+    tokenizer.padding_side = "left"
+    if tokenizer.pad_token is None:
+        tokenizer.pad_token = tokenizer.eos_token
+
     def preprocess_function(example):
         prompt = []
         if training_args.system_prompt is not None:

--- a/src/small_doge/trainer/doge2/pt.py
+++ b/src/small_doge/trainer/doge2/pt.py
@@ -217,7 +217,10 @@ def main(script_args, training_args, model_args, model_config):
     # Load tokenizer
     ################
     tokenizer = AutoTokenizer.from_pretrained(
-        model_args.model_name_or_path, trust_remote_code=model_args.trust_remote_code, use_fast=True
+        model_args.model_name_or_path,
+        revision=model_args.model_revision,
+        use_fast=True,
+        trust_remote_code=model_args.trust_remote_code,
     )
 
     ###################

--- a/src/small_doge/trainer/doge2/sft.py
+++ b/src/small_doge/trainer/doge2/sft.py
@@ -114,7 +114,10 @@ def main(
     # Load tokenizer
     ################
     tokenizer = AutoTokenizer.from_pretrained(
-        model_args.model_name_or_path, trust_remote_code=model_args.trust_remote_code, use_fast=True
+        model_args.model_name_or_path,
+        revision=model_args.model_revision,
+        use_fast=True,
+        trust_remote_code=model_args.trust_remote_code,
     )
     tokenizer.padding_side = "right"
     if tokenizer.pad_token is None:


### PR DESCRIPTION
This pull request updates the tokenizer initialization across multiple files to include the `revision` parameter, ensuring compatibility with specific model revisions. The changes improve consistency and flexibility in loading tokenizers.

### Tokenizer Initialization Updates:

* [`src/small_doge/trainer/doge2/dpo.py`](diffhunk://#diff-e27478dd70bdd7ee3349a55bf4a528602c6f5784cd000196837f49ec46e7301aL118-R121): Added the `revision` parameter to the `AutoTokenizer.from_pretrained` call in `preprocess_function` to support specifying model revisions.
* [`src/small_doge/trainer/doge2/grpo.py`](diffhunk://#diff-2d745ea1acaa1a5ed6d41a425b549aabe3ebf9dcff0264a7604d880c2464a202R449-R461): Introduced tokenizer initialization in the `main` function, including the `revision` parameter and handling for `pad_token` when it is `None`.
* [`src/small_doge/trainer/doge2/pt.py`](diffhunk://#diff-2fc8856133d98e8d4bda2c0f521e8f271034f9e107a10e433b907e5addfc2e5aL220-R223): Updated the `AutoTokenizer.from_pretrained` call in the `main` function to include the `revision` parameter.
* [`src/small_doge/trainer/doge2/sft.py`](diffhunk://#diff-357db68f8a035d8dc05be2e021bf2996b85614b5c4d07955e9a0c67037b581f2L117-R120): Modified the tokenizer initialization in `preprocess_function` to include the `revision` parameter for better model revision handling.