### PR TITLE
Add SFT datasets processor

### DIFF
--- a/src/small_doge/processor/sft_datasets_process.py
+++ b/src/small_doge/processor/sft_datasets_process.py
@@ -1,0 +1,334 @@
+# Copyright 2025 The SmallDoge Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import List, Dict, Optional, Union, Callable
+import logging
+import warnings
+import re
+from datasets import Dataset, IterableDataset, DatasetDict, load_dataset, load_from_disk, concatenate_datasets
+from transformers import AutoTokenizer, PreTrainedTokenizerBase
+from trl.data_utils import pack_dataset, truncate_dataset, is_conversational, maybe_convert_to_chatml, maybe_apply_chat_template
+from trl.trainer.utils import ConstantLengthDataset
+from argparse import ArgumentParser
+from trl import SFTTrainer
+
+
+# Configure logger
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+    datefmt='%Y-%m-%d %H:%M:%S'
+)
+logger = logging.getLogger(__name__)
+
+
+def prepare_dataset(
+    dataset: Union[Dataset, IterableDataset],
+    dataset_name: str,
+    dataset_text_field: str,
+    processing_class: Union[PreTrainedTokenizerBase],
+    max_length: Optional[int],
+    packing: Optional[bool],
+    formatting_func: Optional[Callable[[dict], str]],
+    dataset_num_proc: Optional[int],
+) -> Union[Dataset, IterableDataset]:
+    # Convert the dataset to an IterableDataset if it is a ConstantLengthDataset
+    if isinstance(dataset, ConstantLengthDataset):
+        return dataset
+    
+    # If the dataset is already preprocessed, skip the processing step
+    column_names = list(next(iter(dataset)).keys())
+    is_processed = "input_ids" in column_names
+
+    # Build the kwargs for the `map` function
+    map_kwargs = {}
+    if isinstance(dataset, Dataset):  # InterableDataset does not support num_proc
+        map_kwargs["num_proc"] = dataset_num_proc
+    
+    # Apply the formatting function if any
+    if formatting_func is not None and is_processed:
+        warnings.warn(
+            "You passed a dataset that is already processed (contains an `input_ids` field) together with a "
+            "formatting function. Therefore `formatting_func` will be ignored. Either remove the "
+            "`formatting_func` or pass a dataset that is not already processed.",
+            UserWarning,
+        )
+    
+    if formatting_func is not None and not is_processed:
+        if isinstance(dataset, Dataset):  # `IterableDataset.map` does not support `desc`
+            map_kwargs["desc"] = f"Applying formatting function to {dataset_name} dataset"
+
+        batched = isinstance(formatting_func(next(iter(dataset))), list)
+
+        def _func(example):
+            return {"text": formatting_func(example)}
+
+        dataset = dataset.map(_func, batched=batched, **map_kwargs)
+
+    # If the dataset is prompt-completion, convert it to language modeling type
+    first_example = next(iter(dataset))
+    if "prompt" in first_example.keys() and "completion" in first_example.keys():
+        key = "messages" if is_conversational(first_example) else "text"
+
+        def concat_prompt_completion(example):
+            return {key: example["prompt"] + example["completion"]}
+
+        dataset = dataset.map(concat_prompt_completion, remove_columns=["prompt", "completion"])
+    
+    if not is_processed:
+        # Convert the dataset to ChatML if needed
+        if isinstance(dataset, Dataset):  # `IterableDataset.map` does not support `desc`
+            map_kwargs["desc"] = f"Converting {dataset_name} dataset to ChatML"
+        column_names = next(iter(dataset)).keys()
+        dataset = dataset.map(
+            maybe_convert_to_chatml,
+            remove_columns="conversations" if "conversations" in column_names else None,
+            **map_kwargs,
+        )
+
+        # Apply the chat template if needed
+        if isinstance(dataset, Dataset):  # `IterableDataset.map` does not support `desc`
+            map_kwargs["desc"] = f"Applying chat template to {dataset_name} dataset"
+        column_names = next(iter(dataset)).keys()
+        dataset = dataset.map(
+            maybe_apply_chat_template,
+            fn_kwargs={"tokenizer": processing_class},
+            remove_columns="messages" if "messages" in column_names else None,  # renamed to "text"
+            **map_kwargs,
+        )
+
+        # Tokenize the dataset if needed
+        if isinstance(dataset, Dataset):  # `IterableDataset.map` does not support `desc`
+            map_kwargs["desc"] = f"Tokenizing {dataset_name} dataset"
+
+        def tokenize(example, processing_class, dataset_text_field):
+            processed = processing_class(text=example[dataset_text_field])
+            if (
+                processing_class.eos_token_id is not None
+                and processed["input_ids"][-1] != processing_class.eos_token_id
+            ):
+                processed["input_ids"] = processed["input_ids"] + [processing_class.eos_token_id]
+                processed["attention_mask"] = processed["attention_mask"] + [1]
+            return processed
+
+        dataset = dataset.map(
+            tokenize,
+            fn_kwargs={"processing_class": processing_class, "dataset_text_field": dataset_text_field},
+            **map_kwargs,
+        )
+
+    # Pack or truncate
+    if packing:
+        if max_length is None:
+            raise ValueError("When packing is enabled, `max_length` can't be `None`.")
+        if isinstance(dataset, Dataset):  # `IterableDataset.map` does not support `desc`
+            map_kwargs["desc"] = f"Packing {dataset_name} dataset"
+        dataset = dataset.select_columns("input_ids")
+        dataset = pack_dataset(dataset, max_length, map_kwargs)
+    elif max_length is not None:
+        if isinstance(dataset, Dataset):  # `IterableDataset.map` does not support `desc`
+            map_kwargs["desc"] = f"Truncating {dataset_name} dataset"
+        dataset = truncate_dataset(dataset, max_length, map_kwargs)
+    return dataset
+
+
+def mix_datasets_by_ratio(
+    datasets_and_ratios: List[Dict[str, float]],
+    total_sample_size: int,
+    dataset_text_field: str,
+    processing_class: Union[PreTrainedTokenizerBase],
+    max_length: Optional[int],
+    packing: Optional[bool],
+    formatting_func: Optional[Callable[[dict], str]],
+    dataset_num_proc: Optional[int],
+    seed: Optional[int] = None,
+    cache_dir: Optional[str] = None,
+):
+    """
+    Mix multiple datasets by ratio.
+
+    Args:
+        datasets_and_ratios: List of dictionaries, each containing a dataset and its ratio.
+            Each dictionary contains one key-value pair where key is the dataset name and value is the mixing ratio.
+        total_sample_size: Total sample size for the mixed training dataset.
+        dataset_text_field: Name of the field in the dataset that contains the text.
+        processing_class: Tokenizer class used for processing the text.
+        max_length: Maximum length of processed sequences. Set to None for no limit.
+        packing: Whether to pack sequences for efficiency.
+        formatting_func: Optional formatting function to convert dataset entries to the desired text format.
+        dataset_num_proc: Number of processes to use for dataset processing.
+        seed: Random seed for dataset shuffling to ensure reproducibility.
+        cache_dir: Directory to cache the datasets.
+    
+    Returns:
+        DatasetDict: A dictionary containing all mixed and processed dataset splits.
+    
+    Example:
+    ```python
+        from transformers import AutoTokenizer
+
+        # Define datasets and their mixing ratios
+        datasets_and_ratios = [
+            {"SmallDoge/SmallTalks": 1.0},
+        ]
+
+        # Create tokenizer
+        tokenizer = AutoTokenizer.from_pretrained("SmallDoge/Doge-tokenizer")
+    
+        # Mix datasets
+        mixed_dataset = mix_datasets_by_ratio(
+            datasets_and_ratios=datasets_and_ratios,
+            total_sample_size=10000,
+            dataset_text_field="text",
+            processing_class=tokenizer,
+            max_length=2048,
+            packing=True,
+            formatting_func=None,
+            dataset_num_proc=4,
+            seed=42,
+            cache_dir="./cache",
+        )
+        print(mixed_dataset)
+    ```"""
+
+    # Check if the dataset ratios sum to 1.0
+    total_ratio = sum([list(dataset.values())[0] for dataset in datasets_and_ratios])
+    if total_ratio != 1.0:
+        raise ValueError(f"Total ratio must be 1.0, but got {total_ratio}. Please check your ratios.")
+
+    final_mixed_dataset = {}
+
+    for dataset_and_ratio in datasets_and_ratios:
+        dataset_name, ratio = dataset_and_ratio.popitem()
+
+        # Check subset name
+        windows_drive_pattern = r'^[a-zA-Z]:.*'
+        is_windows_path = bool(re.match(windows_drive_pattern, dataset_name))
+        if ":" in dataset_name and not is_windows_path:
+            dataset_name, subset_name = dataset_name.split(":")
+        else:
+            subset_name = None
+
+        # If the dataset is a string, load it from the hub or disk
+        if isinstance(dataset_name, str):
+            if re.match(r"^[^/]+/[^/]+$", dataset_name):
+                dataset = load_dataset(dataset_name, name=subset_name, cache_dir=cache_dir)
+            else:
+                if subset_name is not None:
+                    warnings.warn(
+                        f"You passed a local dataset path, subsetting is not supported, ignoring subset name: {subset_name}",
+                        UserWarning,
+                    )
+                dataset = load_from_disk(dataset_name)
+
+        # Process each split of the dataset
+        for split_name, split_dataset in dataset.items():
+
+            logger.info(f"Original dataset size for {dataset_name}: {split_name}: {len(split_dataset)}")
+            # Process the dataset from text to input_ids
+            split_dataset = prepare_dataset(
+                split_dataset,
+                dataset_name=f"{dataset_name}: {split_name}" if subset_name is None else f"{dataset_name}: {subset_name}: {split_name}",
+                dataset_text_field=dataset_text_field,
+                processing_class=processing_class,
+                max_length=max_length,
+                packing=packing,
+                formatting_func=formatting_func,
+                dataset_num_proc=dataset_num_proc,
+            )
+            
+
+            # Calculate the target size for the dataset
+            target_size = int(total_sample_size * ratio) if split_name == "train" else len(split_dataset)
+            current_size = len(split_dataset)
+            logger.info(f"Processed dataset size for {dataset_name}: {split_name}: {current_size}")
+            logger.info(f"Target size for {dataset_name}: {split_name}: {target_size}")
+
+            # If the dataset is smaller than the target size, repeat it
+            if current_size < target_size:
+                logger.warning(
+                    f"Dataset {dataset_name}: {split_name} is smaller than the target size. "
+                    f"Repeating the dataset to reach the target size."
+                )
+                indices = []
+                full_copies = target_size // current_size
+                remainder = target_size % current_size
+
+                for _ in range(full_copies):
+                    indices.extend(range(current_size))
+                if remainder > 0:
+                    indices.extend(range(remainder))
+                
+                split_dataset = split_dataset.select(indices)
+            else:
+                logger.warning(
+                    f"Dataset {dataset_name}: {split_name} is larger than the target size. "
+                    f"Truncating the dataset to reach the target size."
+                )
+                split_dataset = split_dataset.select(range(target_size))
+            
+            # Concatenate the split dataset with the final mixed dataset
+            if split_name in final_mixed_dataset:
+                final_mixed_dataset[split_name] = concatenate_datasets(
+                    [final_mixed_dataset[split_name], split_dataset]
+                )
+            else:
+                final_mixed_dataset[split_name] = split_dataset
+         
+    # Shuffle the train dataset
+    if "train" in final_mixed_dataset:
+        final_mixed_dataset["train"] = final_mixed_dataset["train"].shuffle(seed)
+
+    # Create a DatasetDict with the merged datasets
+    final_dataset = DatasetDict(final_mixed_dataset)
+    return final_dataset
+            
+
+def main(args):
+    # Load the tokenizer
+    tokenizer = AutoTokenizer.from_pretrained(args.cache_dir)
+
+    # Mix datasets
+    mixed_dataset = mix_datasets_by_ratio(
+        datasets_and_ratios=args.datasets_and_ratios,
+        total_sample_size=args.total_sample_size,
+        dataset_text_field=args.dataset_text_field,
+        processing_class=tokenizer,
+        max_length=args.max_length,
+        packing=args.packing,
+        formatting_func=None,
+        dataset_num_proc=args.dataset_num_proc,
+        seed=args.seed,
+        cache_dir=args.cache_dir,
+    )
+    
+    # Save the mixed dataset
+    mixed_dataset.save_to_disk(args.dataset_save_path)
+    print(f"Mixed dataset saved to {args.dataset_save_path}")
+
+if __name__ == "__main__":
+    argparser = ArgumentParser()
+    argparser.add_argument("--datasets_and_ratios", type=list[dict[str, float]], required=True)
+    argparser.add_argument("--dataset_save_path", type=str, required=True)
+    argparser.add_argument("--total_sample_size", type=int, required=True)
+    argparser.add_argument("--dataset_text_field", type=str, required=True)
+    argparser.add_argument("--processing_class", type=str, required=True)
+    argparser.add_argument("--max_length", type=int, required=True)
+    argparser.add_argument("--packing", type=bool, required=True)
+    argparser.add_argument("--dataset_num_proc", type=int, required=True)
+    argparser.add_argument("--seed", type=int, default=42)
+    argparser.add_argument("--cache_dir", type=str, default="./cache")
+    args = argparser.parse_args()
+
+    main(args)

--- a/src/small_doge/trainer/doge2/pt.py
+++ b/src/small_doge/trainer/doge2/pt.py
@@ -222,6 +222,9 @@ def main(script_args, training_args, model_args, model_config):
         use_fast=True,
         trust_remote_code=model_args.trust_remote_code,
     )
+    tokenizer.padding_side = "right"
+    if tokenizer.pad_token is None:
+        tokenizer.pad_token = tokenizer.eos_token
 
     ###################
     # Model init kwargs


### PR DESCRIPTION
This pull request introduces new functionality for processing and mixing datasets, along with a minor update to tokenizer configuration. The key changes include the addition of a comprehensive dataset processing module, a utility for mixing datasets by ratio, and improved tokenizer handling for padding.

### Dataset Processing and Mixing:
* **New dataset processing function**: Added `prepare_dataset` in `src/small_doge/processor/sft_datasets_process.py` to handle dataset formatting, tokenization, and optional packing or truncation. This function supports various dataset types and ensures compatibility with ChatML.
* **Dataset mixing utility**: Introduced `mix_datasets_by_ratio` in `src/small_doge/processor/sft_datasets_process.py` to combine multiple datasets based on specified ratios, with support for dataset shuffling, resizing, and caching.
* **Command-line interface**: Added a `main` function to enable dataset mixing via CLI, allowing users to specify datasets, ratios, and processing parameters.

### Tokenizer Configuration:
* **Padding configuration**: Updated `def main` in `src/small_doge/trainer/doge2/pt.py` to set the tokenizer's padding side to "right" and ensure the `pad_token` is defined, defaulting to `eos_token` if not already set.