### PR TITLE
Add Doge2-160M config_full.yaml

### DIFF
--- a/recipes/doge2/Doge2-160M/config_full.yaml
+++ b/recipes/doge2/Doge2-160M/config_full.yaml
@@ -17,7 +17,7 @@ hub_strategy: every_save
 
 # Model arguments
 model_config:
-  vocab_size: 32768
+  vocab_size: 49152
   hidden_size: 576
   intermediate_size: 1536
   num_hidden_layers: 30
@@ -25,16 +25,21 @@ model_config:
   hidden_act: "silu"
   use_cache: True
   tie_word_embeddings: True
-  max_position_embeddings: 2048
-  rope_theta: 10000.0
+  max_position_embeddings: 8192
+  rope_theta: 100000.0
   num_attention_heads: 9
   num_key_value_heads: 3
   is_moe: True
   num_experts: 900
-  num_experts_per_tok: 30
+  num_experts_per_tok: 15
   output_router_logits: True
+  bos_token_id: 0
+  eos_token_id: 0
+  pad_token_id: 0
+  unk_token_id: 0
 
 model_name_or_path: SmallDoge/Doge2-tokenizer
+model_revision: 49152
 torch_dtype: bfloat16
 
 # Data training arguments
@@ -45,7 +50,7 @@ dataset_config: default
 preprocessing_num_workers: 1 # Equal to the number of GPUs you are using
 seed: 233
 do_train: True
-max_steps: 60000
+max_steps: 2000
 per_device_train_batch_size: 1
 do_eval: True
 eval_strategy: steps
@@ -60,7 +65,7 @@ lr_scheduler_type: warmup_stable_decay
 lr_scheduler_kwargs:
   warmup_type: linear
   decay_type: linear
-  num_decay_steps: 12000
+  num_decay_steps: 0
   min_lr_ratio: 0.0
 warmup_steps: 2000
 weight_decay: 0.01


### PR DESCRIPTION
This pull request updates the configuration for the Doge2 model, renaming the file from `Doge2-175M` to `Doge2-160M` and making adjustments to model parameters, training settings, and learning rate scheduling. The changes optimize the model for a smaller configuration and adjust training dynamics.

### Model configuration updates:
* Increased `vocab_size` from 32,768 to 49,152 and `max_position_embeddings` from 2,048 to 8,192. Updated `rope_theta` from 10,000.0 to 100,000.0. Added token IDs (`bos_token_id`, `eos_token_id`, `pad_token_id`, `unk_token_id`) and a `model_revision` field. Reduced `num_experts_per_tok` from 30 to 15.

### Training configuration updates:
* Reduced `max_steps` from 60,000 to 2,000 in the dataset configuration, likely for faster experimentation or fine-tuning.

### Learning rate scheduler updates:
* Set `num_decay_steps` to 0 in the learning rate scheduler configuration, likely to maintain a stable learning rate after the warmup period.