### PR TITLE
Add Doge2-160M-Instruct config files

### DIFF
--- a/recipes/doge2/Doge2-160M-Instruct/dpo/config_full.yaml
+++ b/recipes/doge2/Doge2-160M-Instruct/dpo/config_full.yaml
@@ -1,0 +1,52 @@
+# Logging and Output arguments
+log_level: info
+logging_strategy: steps
+logging_steps: 100
+report_to:
+- tensorboard
+- wandb
+save_strategy: steps
+save_steps: 100
+output_dir: data/Doge2-160M-Instruct-DPO
+overwrite_output_dir: true
+push_to_hub: true
+private: true
+# token: <your-token>
+hub_model_id: Doge2-160M-Instruct-DPO
+hub_strategy: every_save
+
+# Model arguments
+model_name_or_path: SmallDoge/Doge2-160M-Instruct-SFT
+model_revision: main
+trust_remote_code: True
+torch_dtype: bfloat16
+
+# Data training arguments
+dataset_name: ./datasets/dpo_dataset
+dataset_config: default
+max_length: 1024
+max_prompt_length: 512
+
+# DPO Trainer arguments
+preprocessing_num_workers: 1 # Equal to the number of GPUs you are using
+seed: 233
+do_train: True
+num_train_epochs: 2
+per_device_train_batch_size: 1
+do_eval: True
+eval_strategy: steps
+eval_steps: 100
+per_device_eval_batch_size: 1
+optim: adamw_torch
+learning_rate: 4.0e-5
+lr_scheduler_type: cosine_with_min_lr
+lr_scheduler_kwargs:
+  min_lr_rate: 0.1
+warmup_ratio: 0.1
+weight_decay: 0.01
+gradient_accumulation_steps: 128
+gradient_checkpointing: true
+gradient_checkpointing_kwargs:
+  use_reentrant: false
+max_grad_norm: 1.0
+bf16: True

--- a/recipes/doge2/Doge2-160M-Instruct/sft/config_full.yaml
+++ b/recipes/doge2/Doge2-160M-Instruct/sft/config_full.yaml
@@ -1,0 +1,53 @@
+# Logging and Output arguments
+log_level: info
+logging_strategy: steps
+logging_steps: 100
+report_to:
+- tensorboard
+- wandb
+save_strategy: steps
+save_steps: 100
+output_dir: data/Doge2-160M-Instruct-SFT
+overwrite_output_dir: true
+push_to_hub: true
+private: true
+# token: <your-token>
+hub_model_id: Doge2-160M-Instruct-SFT
+hub_strategy: every_save
+
+# Model arguments
+model_name_or_path: SmallDoge/Doge2-160M
+model_revision: main
+trust_remote_code: True
+torch_dtype: bfloat16
+
+# Data training arguments
+dataset_name: SmallDoge/SmallTalks
+dataset_config: default
+dataset_num_proc: 8
+max_seq_length: 2048
+packing: True
+
+# SFT trainer arguments
+preprocessing_num_workers: 1 # Equal to the number of GPUs you are using
+seed: 233
+do_train: True
+num_train_epochs: 2
+per_device_train_batch_size: 1
+do_eval: True
+eval_strategy: steps
+eval_steps: 100
+per_device_eval_batch_size: 1
+optim: adamw_torch
+learning_rate: 4.0e-4
+lr_scheduler_type: cosine_with_min_lr
+lr_scheduler_kwargs:
+  min_lr_rate: 0.1
+warmup_ratio: 0.1
+weight_decay: 0.01
+gradient_accumulation_steps: 128
+gradient_checkpointing: false
+gradient_checkpointing_kwargs:
+  use_reentrant: false
+max_grad_norm: 1.0
+bf16: True


### PR DESCRIPTION
This pull request introduces two new configuration files for training and fine-tuning the Doge2-160M-Instruct model: one for Direct Preference Optimization (DPO) and another for Supervised Fine-Tuning (SFT). These configurations define logging, model, data, and training parameters tailored for each training strategy.

### DPO Configuration (`config_full.yaml` in `recipes/doge2/Doge2-160M-Instruct/dpo`):
* **Logging and Output**: Configured logging to report to TensorBoard and Weights & Biases (WandB), and set up model saving every 100 steps. The model will be pushed to a private Hugging Face hub repository (`Doge2-160M-Instruct-DPO`).
* **Model Settings**: Specifies the base model (`SmallDoge/Doge2-160M-Instruct-SFT`) with `bfloat16` precision and trust for remote code.
* **Data and Training**: Uses a local dataset (`./datasets/dpo_dataset`) with a maximum sequence length of 1024 tokens. Training is configured with 2 epochs, a batch size of 1, and a cosine learning rate scheduler. Gradient checkpointing is enabled.

### SFT Configuration (`config_full.yaml` in `recipes/doge2/Doge2-160M-Instruct/sft`):
* **Logging and Output**: Similar logging setup as DPO but pushes to a different Hugging Face hub repository (`Doge2-160M-Instruct-SFT`).
* **Model Settings**: Specifies the base model (`SmallDoge/Doge2-160M`) with `bfloat16` precision and trust for remote code.
* **Data and Training**: Uses the `SmallDoge/SmallTalks` dataset with sequence packing enabled and a maximum sequence length of 2048 tokens. Training is configured with 2 epochs, a batch size of 1, and a cosine learning rate scheduler. Gradient checkpointing is disabled.