### PR TITLE
Add logic for keep all samples

### DIFF
--- a/src/small_doge/processor/pt_datasets_process.py
+++ b/src/small_doge/processor/pt_datasets_process.py
@@ -225,7 +225,10 @@ def mix_datasets_by_ratio(
             
 
             # Calculate the target size for the dataset
-            target_size = int(total_sample_size * ratio) if split_name == "train" else len(split_dataset)
+            if total_sample_size == -1:
+                target_size = len(split_dataset)
+            else:
+                target_size = int(total_sample_size * ratio) if split_name == "train" else len(split_dataset)
             current_size = len(split_dataset)
             logger.info(f"Processed dataset size for {dataset_name}: {split_name}: {current_size}")
             logger.info(f"Target size for {dataset_name}: {split_name}: {target_size}")

--- a/src/small_doge/processor/sft_datasets_process.py
+++ b/src/small_doge/processor/sft_datasets_process.py
@@ -250,7 +250,10 @@ def mix_datasets_by_ratio(
             
 
             # Calculate the target size for the dataset
-            target_size = int(total_sample_size * ratio) if split_name == "train" else len(split_dataset)
+            if total_sample_size == -1:
+                target_size = len(split_dataset)
+            else:
+                target_size = int(total_sample_size * ratio) if split_name == "train" else len(split_dataset)
             current_size = len(split_dataset)
             logger.info(f"Processed dataset size for {dataset_name}: {split_name}: {current_size}")
             logger.info(f"Target size for {dataset_name}: {split_name}: {target_size}")


### PR DESCRIPTION
This pull request updates the `mix_datasets_by_ratio` function in two files to handle cases where `total_sample_size` is set to `-1`. The change ensures that the entire dataset is used in such cases, improving flexibility in dataset processing.

### Changes to dataset processing logic:

* [`src/small_doge/processor/pt_datasets_process.py`](diffhunk://#diff-9878d1df90499f82ed03599584c2f21fc54f6c2f9afbaf25f1f0cc716c3633a0R228-R230): Updated the `mix_datasets_by_ratio` function to set `target_size` to the length of `split_dataset` when `total_sample_size` is `-1`.
* [`src/small_doge/processor/sft_datasets_process.py`](diffhunk://#diff-dbe7b292253152430c7de5604f84e1731d23381cfc5fe709cece08b1a088f872R253-R255): Applied the same update to the `mix_datasets_by_ratio` function, ensuring consistent behavior across modules.