### PR TITLE
Update eval scripts for latest lighteval

### DIFF
--- a/evaluation/eval_downstream_tasks.ps1
+++ b/evaluation/eval_downstream_tasks.ps1
@@ -1,20 +1,18 @@
 
 $MODEL = "SmallDoge/Doge-160M"
-$MODEL_ARGS="pretrained=$MODEL,trust_remote_code=True,dtype=bfloat16,max_length=2048,generation_parameters={max_new_tokens:2048,temperature:0.6,top_p:0.95}"
+$MODEL_ARGS="model_name=$MODEL,trust_remote_code=True,dtype=bfloat16,max_length=2048,generation_parameters={max_new_tokens:2048,temperature:0.6,top_p:0.95}"
 $OUTPUT_DIR = "./lighteval_results/$MODEL"
 
 if ($MODEL -match "Instruct$") {
     lighteval accelerate $MODEL_ARGS `
     "evaluation/instruct/doge_instruct.txt" `
     --custom-tasks evaluation/instruct/tasks.py `
-    --override-batch-size 1 `
     --use-chat-template `
     --output-dir $OUTPUT_DIR
 } elseif ($MODEL -match "Reason$") {
     lighteval vllm $MODEL_ARGS `
     "evaluation/reason/doge_reason.txt" `
     --custom-tasks evaluation/reason/tasks.py `
-    --override-batch-size 1 `
     --use-chat-template `
     --output-dir $OUTPUT_DIR
 }
@@ -22,6 +20,5 @@ else {
     lighteval accelerate $MODEL_ARGS `
     "evaluation/base/doge_base.txt" `
     --custom-tasks evaluation/base/tasks.py `
-    --override-batch-size 1 `
     --output-dir $OUTPUT_DIR
 }

--- a/evaluation/eval_downstream_tasks.sh
+++ b/evaluation/eval_downstream_tasks.sh
@@ -1,27 +1,24 @@
 #!/bin/bash
 
 MODEL="SmallDoge/Doge-160M"
-MODEL_ARGS="pretrained=$MODEL,trust_remote_code=True,dtype=bfloat16,max_length=2048,generation_parameters={max_new_tokens:2048,temperature:0.6,top_p:0.95}"
+MODEL_ARGS="model_name=$MODEL,trust_remote_code=True,dtype=bfloat16,max_length=2048,generation_parameters={max_new_tokens:2048,temperature:0.6,top_p:0.95}"
 OUTPUT_DIR="./lighteval_results/$MODEL"
 
 if [[ $MODEL =~ Instruct$ ]]; then
     lighteval accelerate $MODEL_ARGS \
     "evaluation/instruct/doge_instruct.txt" \
     --custom-tasks evaluation/instruct/tasks.py \
-    --override-batch-size 1 \
     --use-chat-template \
     --output-dir $OUTPUT_DIR
 elif [[ $MODEL =~ Reason$ ]]; then
     lighteval vllm $MODEL_ARGS \
     "evaluation/reason/doge_reason.txt" \
     --custom-tasks evaluation/reason/tasks.py \
-    --override-batch-size 1 \
     --use-chat-template \
     --output-dir $OUTPUT_DIR
 else
     lighteval accelerate $MODEL_ARGS \
     "evaluation/base/doge_base.txt" \
     --custom-tasks evaluation/base/tasks.py \
-    --override-batch-size 1 \
     --output-dir $OUTPUT_DIR
 fi


### PR DESCRIPTION
This pull request updates the evaluation scripts for downstream tasks by modifying the `MODEL_ARGS` parameter to use a more descriptive key and removing the `--override-batch-size` argument for all task types.

### Updates to `MODEL_ARGS` parameter:
* Changed the key `pretrained` to `model_name` in the `MODEL_ARGS` variable to improve clarity and consistency in both `evaluation/eval_downstream_tasks.ps1` and `evaluation/eval_downstream_tasks.sh`. [[1]](diffhunk://#diff-c8f9721d2f9c8880ce391ffa2283af73444b73a0e652ee21aab3c6f0ebbc0fb9L3-L25) [[2]](diffhunk://#diff-bc5777a9b77db514f9baad35aa8f64b37b1d2cc267b8231c114fa39cabdd00eeL4-L25)

### Removal of `--override-batch-size`:
* Removed the `--override-batch-size 1` argument from all task evaluation commands (`Instruct`, `Reason`, and `Base`) in both `evaluation/eval_downstream_tasks.ps1` and `evaluation/eval_downstream_tasks.sh`. This simplifies the command-line arguments by relying on default batch size behavior. [[1]](diffhunk://#diff-c8f9721d2f9c8880ce391ffa2283af73444b73a0e652ee21aab3c6f0ebbc0fb9L3-L25) [[2]](diffhunk://#diff-bc5777a9b77db514f9baad35aa8f64b37b1d2cc267b8231c114fa39cabdd00eeL4-L25)