### PR TITLE
Add model cards

### DIFF
--- a/docs/Doge-160M-Instruct-SFT.md
+++ b/docs/Doge-160M-Instruct-SFT.md
@@ -1,0 +1,117 @@
+---
+library_name: transformers
+license: apache-2.0
+datasets:
+- HuggingFaceTB/smoltalk
+base_model:
+- SmallDoge/Doge-160M
+language:
+- en
+pipeline_tag: question-answering
+tags:
+- trl
+- sft
+- doge
+---
+
+
+# **Doge 160M Instruct SFT**
+
+<div align="center">
+  <img src="https://huggingface.co/spaces/SmallDoge/README/resolve/main/org_icon.png" width="100%" alt="SmallDoge" />
+</div>
+<hr>
+<div align="center">
+  <a href="https://discord.gg/P2yYH95N" target="_blank" style="margin: 2px;">
+    <img alt="Discord" src="https://img.shields.io/badge/Discord-Small%20Doges-7289da?logo=discord&logoColor=white&color=7289da" style="display: inline-block; vertical-align: middle;"/>
+  </a>
+  <!-- <a href="https://arxiv.org/abs/2412.11834" target="_blank" style="margin: 2px;">
+    <img alt="arXiv" src="https://img.shields.io/static/v1?label=arXiv&message=2412.11834&color=B31B1B&logo=arXiv" style="display: inline-block; vertical-align: middle;"/>
+  </a> -->
+  <a href="https://github.com/SmallDoges/small-doge" target="_blank" style="margin: 2px;">
+    <img alt="GitHub" src="https://img.shields.io/badge/GitHub-SmallDoge-181717?logo=github" style="display: inline-block; vertical-align: middle;"/>
+  </a>
+  <a href="https://github.com/SmallDoges/small-doge/blob/main/LICENSE" style="margin: 2px;">
+    <img alt="License" src="https://img.shields.io/badge/License-Apache--2.0-blue.svg" style="display: inline-block; vertical-align: middle;"/>
+  </a>
+</div>
+
+Doge uses Dynamic Mask Attention as sequence transformation and can use Multi-Layer Perceptron or Cross Domain Mixture of Experts as state transformation. Dynamic Mask Attention allows the Transformer to use self-attention during training and state space during inference, and Cross Domain Mixture of Experts can directly inherit the weights of Multi-Layer Perceptron for further training. This model is trained by [SmallDoge](https://huggingface.co/SmallDoge) community, for detailed algorithm and model architecture, paper coming soon, all training details and code are available in the [small-doge](https://github.com/SmallDoges/small-doge) repository.
+
+
+## Uses
+
+```python
+from transformers import AutoTokenizer, AutoModelForCausalLM, GenerationConfig, TextStreamer
+
+tokenizer = AutoTokenizer.from_pretrained("SmallDoge/Doge-160M-Instruct-SFT")
+model = AutoModelForCausalLM.from_pretrained("SmallDoge/Doge-160M-Instruct-SFT", trust_remote_code=True)
+
+generation_config = GenerationConfig(
+      max_new_tokens=100, 
+      use_cache=True, 
+      do_sample=True, 
+      temperature=0.8, 
+      top_p=0.9,
+      repetition_penalty=1.0
+)
+steamer = TextStreamer(
+      tokenizer=tokenizer, 
+      skip_prompt=True
+)
+
+prompt = "Hi, how are you doing today?"
+conversation = [
+      {"role": "user", "content": prompt}
+]
+inputs = tokenizer.apply_chat_template(
+    conversation=conversation,
+    tokenize=True,
+    return_tensors="pt",
+)
+
+outputs = model.generate(
+    inputs, 
+    tokenizer=tokenizer,
+    generation_config=generation_config, 
+    streamer=steamer
+)
+```
+
+
+## Model Details
+
+We build the Doge-Instruct-SFT by SFT on [SmolTalk](https://huggingface.co/datasets/HuggingFaceTB/smoltalk).
+
+**SFT**:
+| Model | Training Data | Epochs | Content Length | LR | Batch Size | Precision |
+|---|---|---|---|---|---|---|
+| [Doge-20M-Instruct-SFT](https://huggingface.co/SmallDoge/Doge-20M-Instruct-SFT) | [smoltalk](https://huggingface.co/datasets/HuggingFaceTB/smoltalk) | 2 | 2048 | 8e-4 | 0.25M | bfloat16 |
+| [Doge-60M-Instruct-SFT](https://huggingface.co/SmallDoge/Doge-60M-Instruct-SFT) | [smoltalk](https://huggingface.co/datasets/HuggingFaceTB/smoltalk) | 2 | 2048 | 6e-4 | 0.25M | bfloat16 |
+| [Doge-160M-Instruct-SFT](https://huggingface.co/SmallDoge/Doge-160M-Instruct-SFT) | [smoltalk](https://huggingface.co/datasets/HuggingFaceTB/smoltalk) | 2 | 2048 | 4e-4 | 0.25M | bfloat16 |
+| [Doge-320M-Instruct-SFT](https://huggingface.co/SmallDoge/Doge-320M-Instruct-SFT) | [smoltalk](https://huggingface.co/datasets/HuggingFaceTB/smoltalk) | 2 | 2048 | 2e-4 | 0.25M | bfloat16 |
+
+
+**Procedure**:
+
+**SFT**:
+[<img src="https://raw.githubusercontent.com/wandb/assets/main/wandb-github-badge-28.svg" alt="Visualize in Weights & Biases" width="150" height="24"/>](https://wandb.ai/loser_cheems/huggingface/runs/0jht5dro) 
+
+
+**Environment**:
+- Image: nvcr.io/nvidia/pytorch:24.12-py3
+- Hardware: 1x NVIDIA RTX 4090
+- Software: Transformers, TRL
+
+
+## Citation
+
+```bibtex
+@misc{smalldoges,
+  title={SmallDoges: A Family of Dynamic UltraFast Small Language Models}, 
+  author={Jingze, Shi and Yifan, Wu and Bingheng, Wu and Yuyu, Luo},
+  year={2025},
+  month={March},
+  url={https://github.com/SmallDoges/small-doge}
+}
+```

--- a/docs/Doge-160M-Instruct.md
+++ b/docs/Doge-160M-Instruct.md
@@ -1,0 +1,147 @@
+---
+library_name: transformers
+license: apache-2.0
+datasets:
+- HuggingFaceTB/smoltalk
+- HuggingFaceH4/ultrafeedback_binarized
+base_model:
+- SmallDoge/Doge-160M
+language:
+- en
+pipeline_tag: question-answering
+tags:
+- trl
+- sft
+- dpo
+- doge
+---
+
+
+# **Doge 160M Instruct**
+
+<div align="center">
+  <img src="https://huggingface.co/spaces/SmallDoge/README/resolve/main/org_icon.png" width="100%" alt="SmallDoge" />
+</div>
+<hr>
+<div align="center">
+  <a href="https://discord.gg/P2yYH95N" target="_blank" style="margin: 2px;">
+    <img alt="Discord" src="https://img.shields.io/badge/Discord-Small%20Doges-7289da?logo=discord&logoColor=white&color=7289da" style="display: inline-block; vertical-align: middle;"/>
+  </a>
+  <!-- <a href="https://arxiv.org/abs/2412.11834" target="_blank" style="margin: 2px;">
+    <img alt="arXiv" src="https://img.shields.io/static/v1?label=arXiv&message=2412.11834&color=B31B1B&logo=arXiv" style="display: inline-block; vertical-align: middle;"/>
+  </a> -->
+  <a href="https://github.com/SmallDoges/small-doge" target="_blank" style="margin: 2px;">
+    <img alt="GitHub" src="https://img.shields.io/badge/GitHub-SmallDoge-181717?logo=github" style="display: inline-block; vertical-align: middle;"/>
+  </a>
+  <a href="https://github.com/SmallDoges/small-doge/blob/main/LICENSE" style="margin: 2px;">
+    <img alt="License" src="https://img.shields.io/badge/License-Apache--2.0-blue.svg" style="display: inline-block; vertical-align: middle;"/>
+  </a>
+</div>
+
+Doge uses Dynamic Mask Attention as sequence transformation and can use Multi-Layer Perceptron or Cross Domain Mixture of Experts as state transformation. Dynamic Mask Attention allows the Transformer to use self-attention during training and state space during inference, and Cross Domain Mixture of Experts can directly inherit the weights of Multi-Layer Perceptron for further training. This model is trained by [SmallDoge](https://huggingface.co/SmallDoge) community, for detailed algorithm and model architecture, paper coming soon, all training details and code are available in the [small-doge](https://github.com/SmallDoges/small-doge) repository.
+
+
+## Uses
+
+```python
+from transformers import AutoTokenizer, AutoModelForCausalLM, GenerationConfig, TextStreamer
+
+tokenizer = AutoTokenizer.from_pretrained("SmallDoge/Doge-160M-Instruct")
+model = AutoModelForCausalLM.from_pretrained("SmallDoge/Doge-160M-Instruct", trust_remote_code=True)
+
+generation_config = GenerationConfig(
+      max_new_tokens=100, 
+      use_cache=True, 
+      do_sample=True, 
+      temperature=0.8, 
+      top_p=0.9,
+      repetition_penalty=1.0
+)
+steamer = TextStreamer(
+      tokenizer=tokenizer, 
+      skip_prompt=True
+)
+
+prompt = "Hi, how are you doing today?"
+conversation = [
+      {"role": "user", "content": prompt}
+]
+inputs = tokenizer.apply_chat_template(
+    conversation=conversation,
+    tokenize=True,
+    return_tensors="pt",
+)
+
+outputs = model.generate(
+    inputs, 
+    tokenizer=tokenizer,
+    generation_config=generation_config, 
+    streamer=steamer
+)
+```
+
+
+## Model Details
+
+We build the Doge-Instruct by first SFT on [SmolTalk](https://huggingface.co/datasets/HuggingFaceTB/smoltalk) and then DPO on [UltraFeedback Binarized](https://huggingface.co/datasets/HuggingFaceH4/ultrafeedback_binarized).
+
+
+**SFT**:
+| Model | Training Data | Epochs | Content Length | LR | Batch Size | Precision |
+|---|---|---|---|---|---|---|
+| [Doge-20M-Instruct-SFT](https://huggingface.co/SmallDoge/Doge-20M-Instruct-SFT) | [smoltalk](https://huggingface.co/datasets/HuggingFaceTB/smoltalk) | 2 | 2048 | 8e-4 | 0.25M | bfloat16 |
+| [Doge-20M-MoE-Instruct-SFT](https://huggingface.co/SmallDoge/Doge-20M-MoE-Instruct-SFT) | [smoltalk](https://huggingface.co/datasets/HuggingFaceTB/smoltalk) | 2 | 2048 | 8e-4 | 0.25M | bfloat16 |
+| [Doge-60M-Instruct-SFT](https://huggingface.co/SmallDoge/Doge-60M-Instruct-SFT) | [smoltalk](https://huggingface.co/datasets/HuggingFaceTB/smoltalk) | 2 | 2048 | 6e-4 | 0.25M | bfloat16 |
+| [Doge-120M-MoE-Instruct-SFT](https://huggingface.co/SmallDoge/Doge-120M-MoE-Instruct-SFT) | [smoltalk](https://huggingface.co/datasets/HuggingFaceTB/smoltalk) | 2 | 2048 | 6e-4 | 0.25M | bfloat16 |
+| [Doge-160M-Instruct-SFT](https://huggingface.co/SmallDoge/Doge-160M-Instruct-SFT) | [smoltalk](https://huggingface.co/datasets/HuggingFaceTB/smoltalk) | 2 | 2048 | 4e-4 | 0.25M | bfloat16 |
+| [Doge-320M-Instruct-SFT](https://huggingface.co/SmallDoge/Doge-320M-Instruct-SFT) | [smoltalk](https://huggingface.co/datasets/HuggingFaceTB/smoltalk) | 2 | 2048 | 2e-4 | 0.25M | bfloat16 |
+
+**DPO**:
+| Model | Training Data | Epochs | Content Length | LR | Batch Size | Precision |
+|---|---|---|---|---|---|---|
+| [Doge-20M-Instruct](https://huggingface.co/SmallDoge/Doge-20M-Instruct) | [ultrafeedback_binarized](https://huggingface.co/datasets/HuggingFaceH4/ultrafeedback_binarized) | 2 | 1024 | 8e-5 | 0.125M | bfloat16 |
+| [Doge-20M-MoE-Instruct](https://huggingface.co/SmallDoge/Doge-20M-MoE-Instruct) | [ultrafeedback_binarized](https://huggingface.co/datasets/HuggingFaceH4/ultrafeedback_binarized) | 2 | 1024 | 8e-5 | 0.125M | bfloat16 |
+| [Doge-60M-Instruct](https://huggingface.co/SmallDoge/Doge-60M-Instruct) | [ultrafeedback_binarized](https://huggingface.co/datasets/HuggingFaceH4/ultrafeedback_binarized) | 2 | 1024 | 6e-5 | 0.125M | bfloat16 |
+| [Doge-120M-MoE-Instruct](https://huggingface.co/SmallDoge/Doge-120M-MoE-Instruct) | [ultrafeedback_binarized](https://huggingface.co/datasets/HuggingFaceH4/ultrafeedback_binarized) | 2 | 1024 | 6e-5 | 0.125M | bfloat16 |
+| [Doge-160M-Instruct](https://huggingface.co/SmallDoge/Doge-160M-Instruct) | [ultrafeedback_binarized](https://huggingface.co/datasets/HuggingFaceH4/ultrafeedback_binarized) | 2 | 1024 | 4e-5 | 0.125M | bfloat16 |
+| [Doge-320M-Instruct](https://huggingface.co/SmallDoge/Doge-320M-Instruct) | [ultrafeedback_binarized](https://huggingface.co/datasets/HuggingFaceH4/ultrafeedback_binarized) | 2 | 1024 | 2e-5 | 0.125M | bfloat16 |
+
+
+**Evaluation**:
+
+| Model | IFEval (Prompt Strict Acc) | MMLU | BBH | ARC | PIQA | HellaSwag | tokens / s on i7-11 CPU |
+|---|---|---|---|---|---|---|---|
+| [Doge-20M-Instruct](https://huggingface.co/SmallDoge/Doge-20M-Instruct) | 9.2 | 26.3 | 18.3 | 29.2 | 57.8 | 27.8 | 142 |
+| [Doge-20M-MoE-Instruct](https://huggingface.co/SmallDoge/Doge-20M-MoE-Instruct) | 13.7 | 26.5 | 26.3 | 31.1 | 58.2 | 27.9 | 132 |
+| [Doge-60M-Instruct](https://huggingface.co/SmallDoge/Doge-60M-Instruct) | 9.4 | 27.5 | 27.7 | 37.5 | 61.4 | 32.1 | 62 |
+| [Doge-120M-MoE-Instruct](https://huggingface.co/SmallDoge/Doge-120M-MoE-Instruct) | 24.4 | 28.2 | 30.1 | 44.2 | 62.1 | 36.3 | 58 |
+| [Doge-160M-Instruct](https://huggingface.co/SmallDoge/Doge-160M-Instruct) | 16.8 | 29.7 | 29.1 | 42.8 | 64.1 | 37.1 | 28 |
+| [Doge-320M-Instruct](https://huggingface.co/SmallDoge/Doge-320M-Instruct) | 28.5 | 30.3 | 31.9 | 51.7 | 71.0 | 50.6 | 16 |
+
+
+**Procedure**:
+
+**SFT**:
+[<img src="https://raw.githubusercontent.com/wandb/assets/main/wandb-github-badge-28.svg" alt="Visualize in Weights & Biases" width="150" height="24"/>](https://wandb.ai/loser_cheems/huggingface/runs/0jht5dro) 
+
+**DPO**:
+[<img src="https://raw.githubusercontent.com/wandb/assets/main/wandb-github-badge-28.svg" alt="Visualize in Weights & Biases" width="150" height="24"/>](https://wandb.ai/loser_cheems/huggingface/runs/m5onn07v)
+
+
+**Environment**:
+- Image: nvcr.io/nvidia/pytorch:24.12-py3
+- Hardware: 1x NVIDIA RTX 4090
+- Software: Transformers, TRL
+
+
+## Citation
+
+```bibtex
+@misc{smalldoges,
+  title={SmallDoges: A Family of Dynamic UltraFast Small Language Models}, 
+  author={Jingze, Shi and Yifan, Wu and Bingheng, Wu and Yuyu, Luo},
+  year={2025},
+  month={March},
+  url={https://github.com/SmallDoges/small-doge}
+}
+```

--- a/docs/Doge-160M-Reason-Distill.md
+++ b/docs/Doge-160M-Reason-Distill.md
@@ -1,0 +1,125 @@
+---
+library_name: transformers
+license: apache-2.0
+datasets:
+- open-thoughts/OpenThoughts-114k
+- open-r1/OpenR1-Math-220k
+- SmallDoge/Reason-Distill
+base_model:
+- SmallDoge/Doge-160M
+language:
+- en
+pipeline_tag: question-answering
+tags:
+- trl
+- sft
+- grpo
+- doge
+---
+
+
+# **Doge 160M Reason Distill**
+
+<div align="center">
+  <img src="https://huggingface.co/spaces/SmallDoge/README/resolve/main/org_icon.png" width="100%" alt="SmallDoge" />
+</div>
+<hr>
+<div align="center">
+  <a href="https://discord.gg/P2yYH95N" target="_blank" style="margin: 2px;">
+    <img alt="Discord" src="https://img.shields.io/badge/Discord-Small%20Doges-7289da?logo=discord&logoColor=white&color=7289da" style="display: inline-block; vertical-align: middle;"/>
+  </a>
+  <a href="https://arxiv.org/abs/2412.11834" target="_blank" style="margin: 2px;">
+    <img alt="arXiv" src="https://img.shields.io/static/v1?label=arXiv&message=2412.11834&color=B31B1B&logo=arXiv" style="display: inline-block; vertical-align: middle;"/>
+  </a>
+  <a href="https://github.com/SmallDoges/small-doge" target="_blank" style="margin: 2px;">
+    <img alt="GitHub" src="https://img.shields.io/badge/GitHub-SmallDoge-181717?logo=github" style="display: inline-block; vertical-align: middle;"/>
+  </a>
+  <a href="https://github.com/SmallDoges/small-doge/blob/main/LICENSE" style="margin: 2px;">
+    <img alt="License" src="https://img.shields.io/badge/License-Apache--2.0-blue.svg" style="display: inline-block; vertical-align: middle;"/>
+  </a>
+</div>
+
+Doge uses Dynamic Mask Attention as sequence transformation and can use Multi-Layer Perceptron or Cross Domain Mixture of Experts as state transformation. Dynamic Mask Attention allows the Transformer to use self-attention during training and state space during inference, and Cross Domain Mixture of Experts can directly inherit the weights of Multi-Layer Perceptron for further training. This model is trained by [SmallDoge](https://huggingface.co/SmallDoge) community, for detailed algorithm and model architecture, please refer to [Wonderful Matrices](https://arxiv.org/abs/2412.11834), all training details and code are publicly available on the [small-doge](https://github.com/SmallDoges/small-doge) repository.
+
+
+## Uses
+
+```python
+from transformers import AutoTokenizer, AutoModelForCausalLM, GenerationConfig, TextStreamer
+
+tokenizer = AutoTokenizer.from_pretrained("SmallDoge/Doge-160M-Reason-Distill")
+model = AutoModelForCausalLM.from_pretrained("SmallDoge/Doge-160M-Reason-Distill", trust_remote_code=True)
+
+generation_config = GenerationConfig(
+      max_new_tokens=100, 
+      use_cache=True, 
+      do_sample=True, 
+      temperature=0.8, 
+      top_p=0.9,
+      repetition_penalty=1.0
+)
+steamer = TextStreamer(
+      tokenizer=tokenizer, 
+      skip_prompt=True
+)
+
+system_prompt = """
+Your role as an assistant involves thoroughly exploring questions through a systematic long thinking process before providing the final precise and accurate solutions. This requires engaging in a comprehensive cycle of analysis, summarizing, exploration, reassessment, reflection, backtracing, and iteration to develop well-considered thinking process. Please structure your response into two main sections: Thought and Solution. In the Thought section, detail your reasoning process using the specified format: <|begin_of_thought|> {thought with steps separated with '\n\n'} <|end_of_thought|> Each step should include detailed considerations such as analisying questions, summarizing relevant findings, brainstorming new ideas, verifying the accuracy of the current steps, refining any errors, and revisiting previous steps. In the Solution section, based on various attempts, explorations, and reflections from the Thought section, systematically present the final solution that you deem correct. The solution should remain a logical, accurate, concise expression style and detail necessary step needed to reach the conclusion, formatted as follows: <|begin_of_solution|> {final formatted, precise, and clear solution} <|end_of_solution|> Now, try to solve the following question through the above guidelines:
+""".strip()
+prompt = "Which number is bigger, 3.9 or 3.11?"
+conversation = [
+    {"role": "system", "content": system_prompt},
+    {"role": "user", "content": prompt}
+]
+inputs = tokenizer.apply_chat_template(
+    conversation=conversation,
+    tokenize=True,
+    return_tensors="pt",
+)
+
+outputs = model.generate(
+    inputs, 
+    tokenizer=tokenizer,
+    generation_config=generation_config, 
+    streamer=steamer
+)
+```
+
+
+## Model Details
+
+We build the Doge-Reason-Distill by SFT on [Reason-Distill](https://huggingface.co/datasets/SmallDoge/Reason-Distill).
+
+> TODO: The larger model is under training and will be uploaded soon.
+
+**SFT**:
+| Model | Training Data | Epochs | Content Length | LR | Batch Size | Precision |
+|---|---|---|---|---|---|---|
+| [Doge-160M-Reason-Distil](https://huggingface.co/SmallDoge/Doge-160M-Reason-Distill) | [SmallDoge/Reason-Distill](https://huggingface.co/datasets/SmallDoge/Reason-Distill) | 2 | 4096 | 4e-4 | 0.5M | bfloat16 |
+
+
+**Procedure**:
+
+**SFT**:
+[<img src="https://raw.githubusercontent.com/wandb/assets/main/wandb-github-badge-28.svg" alt="Visualize in Weights & Biases" width="150" height="24"/>](https://wandb.ai/loser_cheems/huggingface/runs/zgk4eefz) 
+
+
+**Environment**:
+- Image: nvcr.io/nvidia/pytorch:24.12-py3
+- Hardware: 1x NVIDIA RTX 4090
+- Software: Transformers, TRL
+
+
+## Citation
+
+```bibtex
+@misc{shi2024wonderfulmatrices,
+      title={Wonderful Matrices: Combining for a More Efficient and Effective Foundation Model Architecture}, 
+      author={Jingze Shi and Bingheng Wu},
+      year={2024},
+      eprint={2412.11834},
+      archivePrefix={arXiv},
+      primaryClass={cs.LG},
+      url={https://arxiv.org/abs/2412.11834}, 
+}
+```

--- a/docs/Doge-160M.md
+++ b/docs/Doge-160M.md
@@ -1,0 +1,98 @@
+---
+library_name: transformers
+license: apache-2.0
+datasets:
+- HuggingFaceTB/smollm-corpus
+language:
+- en
+pipeline_tag: text-generation
+tags:
+- pt
+- doge
+---
+
+
+# **Doge 160M**
+
+<div align="center">
+  <img src="https://huggingface.co/spaces/SmallDoge/README/resolve/main/org_icon.png" width="100%" alt="SmallDoge" />
+</div>
+<hr>
+<div align="center">
+  <a href="https://discord.gg/P2yYH95N" target="_blank" style="margin: 2px;">
+    <img alt="Discord" src="https://img.shields.io/badge/Discord-Small%20Doges-7289da?logo=discord&logoColor=white&color=7289da" style="display: inline-block; vertical-align: middle;"/>
+  </a>
+  <!-- <a href="https://arxiv.org/abs/2412.11834" target="_blank" style="margin: 2px;">
+    <img alt="arXiv" src="https://img.shields.io/static/v1?label=arXiv&message=2412.11834&color=B31B1B&logo=arXiv" style="display: inline-block; vertical-align: middle;"/>
+  </a> -->
+  <a href="https://github.com/SmallDoges/small-doge" target="_blank" style="margin: 2px;">
+    <img alt="GitHub" src="https://img.shields.io/badge/GitHub-SmallDoge-181717?logo=github" style="display: inline-block; vertical-align: middle;"/>
+  </a>
+  <a href="https://github.com/SmallDoges/small-doge/blob/main/LICENSE" style="margin: 2px;">
+    <img alt="License" src="https://img.shields.io/badge/License-Apache--2.0-blue.svg" style="display: inline-block; vertical-align: middle;"/>
+  </a>
+</div>
+
+Doge uses Dynamic Mask Attention as sequence transformation and can use Multi-Layer Perceptron or Cross Domain Mixture of Experts as state transformation. Dynamic Mask Attention allows the Transformer to use self-attention during training and state space during inference, and Cross Domain Mixture of Experts can directly inherit the weights of Multi-Layer Perceptron for further training. This model is trained by [SmallDoge](https://huggingface.co/SmallDoge) community, for detailed algorithm and model architecture, paper coming soon, all training details and code are available in the [small-doge](https://github.com/SmallDoges/small-doge) repository.
+
+
+
+## Uses
+
+```python
+>>> from transformers import AutoTokenizer, AutoModelForCausalLM
+
+>>> tokenizer = AutoTokenizer.from_pretrained("SmallDoge/Doge-160M")
+>>> model = AutoModelForCausalLM.from_pretrained("SmallDoge/Doge-160M", trust_remote_code=True)
+>>> inputs = tokenizer("Hey how are you doing?", return_tensors="pt")
+
+>>> out = model.generate(**inputs, max_new_tokens=100)
+>>> print(tokenizer.batch_decode(out))
+```
+
+
+## Model Details
+
+We build the Doge by doing Per-Training on [Smollm-Corpus](https://huggingface.co/datasets/HuggingFaceTB/smollm-corpus). If you want to continue pre-training this model, you can find the unconverged checkpoint [here](https://huggingface.co/SmallDoge/Doge-160M-checkpoint). These models has not been fine-tuned for instruction, the instruction model is [here](https://huggingface.co/SmallDoge/Doge-160M-Instruct).
+
+
+**Pre-Training**:
+
+| Model | Training Data | Steps | Content Length | Tokens | LR | Batch Size | Precision | RTX 4090 GPU hours |
+|---|---|---|---|---|---|---|---|---|
+| [Doge-20M](https://huggingface.co/SmallDoge/Doge-20M) | [smollm-corpus](https://huggingface.co/datasets/HuggingFaceTB/smollm-corpus) | 8k  | 2048 | 4B | 8e-3 | 0.5M | bfloat16 | 14 |
+| [Doge-60M](https://huggingface.co/SmallDoge/Doge-60M) | [smollm-corpus](https://huggingface.co/datasets/HuggingFaceTB/smollm-corpus) | 16k  | 2048 | 16B | 6e-3 | 1M | bfloat16 | 128 |
+| [Doge-160M](https://huggingface.co/SmallDoge/Doge-160M) | [smollm-corpus](https://huggingface.co/datasets/HuggingFaceTB/smollm-corpus) | 24k  | 2048 | 32B | 4e-3 | 1.5M | bfloat16 | 522 |
+| [Doge-320M](https://huggingface.co/SmallDoge/Doge-320M) | [smollm-corpus](https://huggingface.co/datasets/HuggingFaceTB/smollm-corpus) | 32k  | 2048 | 64B | 2e-3 | 2M | bfloat16 | 1856 |
+
+**Evaluation**:
+
+| Model | MMLU | TriviaQA | ARC | PIQA | HellaSwag | OBQA | Winogrande | tokens / s on i7-11 CPU |
+|---|---|---|---|---|---|---|---|---|
+| [Doge-20M](https://huggingface.co/SmallDoge/Doge-20M) | 25.4 | 0.03 | 29.8 | 58.4 | 27.3 | 25.6 | 50.2 | 142 |
+| [Doge-60M](https://huggingface.co/SmallDoge/Doge-60M) | 26.4 | 0.2 | 37.9 | 61.4 | 31.5 | 28.0 | 50.8 | 62 |
+| [Doge-160M](https://huggingface.co/SmallDoge/Doge-160M) | 29.2 | 4.8 | 44.4 | 70.1 | 43.4 | 34.4 | 52.2 | 28 |
+| [Doge-320M](https://huggingface.co/SmallDoge/Doge-320M) | 35.6 | 9.4 | 55.4 | 73.9 | 52.7 | 37.9 | 59.3 | 16 |
+
+**Procedure**:
+
+[<img src="https://raw.githubusercontent.com/wandb/assets/main/wandb-github-badge-28.svg" alt="Visualize in Weights & Biases" width="150" height="24"/>](https://wandb.ai/loser_cheems/huggingface/runs/3uyc9a89) 
+
+**Environment**:
+
+- Image: nvcr.io/nvidia/pytorch:24.12-py3
+- Hardware: 1x NVIDIA RTX 4090
+- Software: Transformers
+
+
+## Citation
+
+```bibtex
+@misc{smalldoges,
+  title={SmallDoges: A Family of Dynamic UltraFast Small Language Models}, 
+  author={Jingze, Shi and Yifan, Wu and Bingheng, Wu and Yuyu, Luo},
+  year={2025},
+  month={March},
+  url={https://github.com/SmallDoges/small-doge}
+}
+```

--- a/docs/Doge-20M-Instruct-SFT.md
+++ b/docs/Doge-20M-Instruct-SFT.md
@@ -1,0 +1,119 @@
+---
+library_name: transformers
+license: apache-2.0
+datasets:
+- HuggingFaceTB/smoltalk
+base_model:
+- SmallDoge/Doge-20M
+language:
+- en
+pipeline_tag: question-answering
+tags:
+- trl
+- sft
+- doge
+---
+
+
+# **Doge 20M Instruct SFT**
+
+<div align="center">
+  <img src="https://huggingface.co/spaces/SmallDoge/README/resolve/main/org_icon.png" width="100%" alt="SmallDoge" />
+</div>
+<hr>
+<div align="center">
+  <a href="https://discord.gg/P2yYH95N" target="_blank" style="margin: 2px;">
+    <img alt="Discord" src="https://img.shields.io/badge/Discord-Small%20Doges-7289da?logo=discord&logoColor=white&color=7289da" style="display: inline-block; vertical-align: middle;"/>
+  </a>
+  <!-- <a href="https://arxiv.org/abs/2412.11834" target="_blank" style="margin: 2px;">
+    <img alt="arXiv" src="https://img.shields.io/static/v1?label=arXiv&message=2412.11834&color=B31B1B&logo=arXiv" style="display: inline-block; vertical-align: middle;"/>
+  </a> -->
+  <a href="https://github.com/SmallDoges/small-doge" target="_blank" style="margin: 2px;">
+    <img alt="GitHub" src="https://img.shields.io/badge/GitHub-SmallDoge-181717?logo=github" style="display: inline-block; vertical-align: middle;"/>
+  </a>
+  <a href="https://github.com/SmallDoges/small-doge/blob/main/LICENSE" style="margin: 2px;">
+    <img alt="License" src="https://img.shields.io/badge/License-Apache--2.0-blue.svg" style="display: inline-block; vertical-align: middle;"/>
+  </a>
+</div>
+
+Doge uses Dynamic Mask Attention as sequence transformation and can use Multi-Layer Perceptron or Cross Domain Mixture of Experts as state transformation. Dynamic Mask Attention allows the Transformer to use self-attention during training and state space during inference, and Cross Domain Mixture of Experts can directly inherit the weights of Multi-Layer Perceptron for further training. This model is trained by [SmallDoge](https://huggingface.co/SmallDoge) community, for detailed algorithm and model architecture, paper coming soon, all training details and code are available in the [small-doge](https://github.com/SmallDoges/small-doge) repository.
+
+
+## Uses
+
+```python
+from transformers import AutoTokenizer, AutoModelForCausalLM, GenerationConfig, TextStreamer
+
+tokenizer = AutoTokenizer.from_pretrained("SmallDoge/Doge-20M-Instruct-SFT")
+model = AutoModelForCausalLM.from_pretrained("SmallDoge/Doge-20M-Instruct-SFT", trust_remote_code=True)
+
+generation_config = GenerationConfig(
+      max_new_tokens=100, 
+      use_cache=True, 
+      do_sample=True, 
+      temperature=0.8, 
+      top_p=0.9,
+      repetition_penalty=1.0
+)
+steamer = TextStreamer(
+      tokenizer=tokenizer, 
+      skip_prompt=True
+)
+
+prompt = "Hi, how are you doing today?"
+conversation = [
+      {"role": "user", "content": prompt}
+]
+inputs = tokenizer.apply_chat_template(
+    conversation=conversation,
+    tokenize=True,
+    return_tensors="pt",
+)
+
+outputs = model.generate(
+    inputs, 
+    tokenizer=tokenizer,
+    generation_config=generation_config, 
+    streamer=steamer
+)
+```
+
+
+## Model Details
+
+We build the Doge-Instruct-SFT by SFT on [SmolTalk](https://huggingface.co/datasets/HuggingFaceTB/smoltalk).
+
+**SFT**:
+| Model | Training Data | Epochs | Content Length | LR | Batch Size | Precision |
+|---|---|---|---|---|---|---|
+| [Doge-20M-Instruct-SFT](https://huggingface.co/SmallDoge/Doge-20M-Instruct-SFT) | [smoltalk](https://huggingface.co/datasets/HuggingFaceTB/smoltalk) | 2 | 2048 | 8e-4 | 0.25M | bfloat16 |
+| [Doge-60M-Instruct-SFT](https://huggingface.co/SmallDoge/Doge-60M-Instruct-SFT) | [smoltalk](https://huggingface.co/datasets/HuggingFaceTB/smoltalk) | 2 | 2048 | 6e-4 | 0.25M | bfloat16 |
+| [Doge-160M-Instruct-SFT](https://huggingface.co/SmallDoge/Doge-160M-Instruct-SFT) | [smoltalk](https://huggingface.co/datasets/HuggingFaceTB/smoltalk) | 2 | 2048 | 4e-4 | 0.25M | bfloat16 |
+| [Doge-320M-Instruct-SFT](https://huggingface.co/SmallDoge/Doge-320M-Instruct-SFT) | [smoltalk](https://huggingface.co/datasets/HuggingFaceTB/smoltalk) | 2 | 2048 | 2e-4 | 0.25M | bfloat16 |
+
+
+**Procedure**:
+
+**SFT**:
+[<img src="https://raw.githubusercontent.com/wandb/assets/main/wandb-github-badge-28.svg" alt="Visualize in Weights & Biases" width="150" height="24"/>](https://wandb.ai/loser_cheems/huggingface/runs/eohr6fuj) 
+
+
+**Environment**:
+- Image: nvcr.io/nvidia/pytorch:24.12-py3
+- Hardware: 1x NVIDIA RTX 4090
+- Software: Transformers, TRL
+
+
+## Citation
+
+```bibtex
+@misc{shi2024wonderfulmatrices,
+      title={Wonderful Matrices: Combining for a More Efficient and Effective Foundation Model Architecture}, 
+      author={Jingze Shi and Bingheng Wu},
+      year={2024},
+      eprint={2412.11834},
+      archivePrefix={arXiv},
+      primaryClass={cs.LG},
+      url={https://arxiv.org/abs/2412.11834}, 
+}
+```

--- a/docs/Doge-20M-Instruct.md
+++ b/docs/Doge-20M-Instruct.md
@@ -1,0 +1,146 @@
+---
+library_name: transformers
+license: apache-2.0
+datasets:
+- HuggingFaceTB/smoltalk
+- HuggingFaceH4/ultrafeedback_binarized
+base_model:
+- SmallDoge/Doge-20M
+language:
+- en
+pipeline_tag: question-answering
+tags:
+- trl
+- sft
+- dpo
+- doge
+---
+
+
+# **Doge 20M Instruct**
+
+<div align="center">
+  <img src="https://huggingface.co/spaces/SmallDoge/README/resolve/main/org_icon.png" width="100%" alt="SmallDoge" />
+</div>
+<hr>
+<div align="center">
+  <a href="https://discord.gg/P2yYH95N" target="_blank" style="margin: 2px;">
+    <img alt="Discord" src="https://img.shields.io/badge/Discord-Small%20Doges-7289da?logo=discord&logoColor=white&color=7289da" style="display: inline-block; vertical-align: middle;"/>
+  </a>
+  <!-- <a href="https://arxiv.org/abs/2412.11834" target="_blank" style="margin: 2px;">
+    <img alt="arXiv" src="https://img.shields.io/static/v1?label=arXiv&message=2412.11834&color=B31B1B&logo=arXiv" style="display: inline-block; vertical-align: middle;"/>
+  </a> -->
+  <a href="https://github.com/SmallDoges/small-doge" target="_blank" style="margin: 2px;">
+    <img alt="GitHub" src="https://img.shields.io/badge/GitHub-SmallDoge-181717?logo=github" style="display: inline-block; vertical-align: middle;"/>
+  </a>
+  <a href="https://github.com/SmallDoges/small-doge/blob/main/LICENSE" style="margin: 2px;">
+    <img alt="License" src="https://img.shields.io/badge/License-Apache--2.0-blue.svg" style="display: inline-block; vertical-align: middle;"/>
+  </a>
+</div>
+
+Doge uses Dynamic Mask Attention as sequence transformation and can use Multi-Layer Perceptron or Cross Domain Mixture of Experts as state transformation. Dynamic Mask Attention allows the Transformer to use self-attention during training and state space during inference, and Cross Domain Mixture of Experts can directly inherit the weights of Multi-Layer Perceptron for further training. This model is trained by [SmallDoge](https://huggingface.co/SmallDoge) community, for detailed algorithm and model architecture, paper coming soon, all training details and code are available in the [small-doge](https://github.com/SmallDoges/small-doge) repository.
+
+
+## Uses
+
+```python
+from transformers import AutoTokenizer, AutoModelForCausalLM, GenerationConfig, TextStreamer
+
+tokenizer = AutoTokenizer.from_pretrained("SmallDoge/Doge-20M-Instruct")
+model = AutoModelForCausalLM.from_pretrained("SmallDoge/Doge-20M-Instruct", trust_remote_code=True)
+
+generation_config = GenerationConfig(
+      max_new_tokens=100, 
+      use_cache=True, 
+      do_sample=True, 
+      temperature=0.8, 
+      top_p=0.9,
+      repetition_penalty=1.0
+)
+steamer = TextStreamer(
+      tokenizer=tokenizer, 
+      skip_prompt=True
+)
+
+prompt = "Hi, how are you doing today?"
+conversation = [
+      {"role": "user", "content": prompt}
+]
+inputs = tokenizer.apply_chat_template(
+    conversation=conversation,
+    tokenize=True,
+    return_tensors="pt",
+)
+
+outputs = model.generate(
+    inputs, 
+    tokenizer=tokenizer,
+    generation_config=generation_config, 
+    streamer=steamer
+)
+```
+
+
+## Model Details
+
+We build the Doge-Instruct by first SFT on [SmolTalk](https://huggingface.co/datasets/HuggingFaceTB/smoltalk) and then DPO on [UltraFeedback Binarized](https://huggingface.co/datasets/HuggingFaceH4/ultrafeedback_binarized).
+
+**SFT**:
+| Model | Training Data | Epochs | Content Length | LR | Batch Size | Precision |
+|---|---|---|---|---|---|---|
+| [Doge-20M-Instruct-SFT](https://huggingface.co/SmallDoge/Doge-20M-Instruct-SFT) | [smoltalk](https://huggingface.co/datasets/HuggingFaceTB/smoltalk) | 2 | 2048 | 8e-4 | 0.25M | bfloat16 |
+| [Doge-20M-MoE-Instruct-SFT](https://huggingface.co/SmallDoge/Doge-20M-MoE-Instruct-SFT) | [smoltalk](https://huggingface.co/datasets/HuggingFaceTB/smoltalk) | 2 | 2048 | 8e-4 | 0.25M | bfloat16 |
+| [Doge-60M-Instruct-SFT](https://huggingface.co/SmallDoge/Doge-60M-Instruct-SFT) | [smoltalk](https://huggingface.co/datasets/HuggingFaceTB/smoltalk) | 2 | 2048 | 6e-4 | 0.25M | bfloat16 |
+| [Doge-120M-MoE-Instruct-SFT](https://huggingface.co/SmallDoge/Doge-120M-MoE-Instruct-SFT) | [smoltalk](https://huggingface.co/datasets/HuggingFaceTB/smoltalk) | 2 | 2048 | 6e-4 | 0.25M | bfloat16 |
+| [Doge-160M-Instruct-SFT](https://huggingface.co/SmallDoge/Doge-160M-Instruct-SFT) | [smoltalk](https://huggingface.co/datasets/HuggingFaceTB/smoltalk) | 2 | 2048 | 4e-4 | 0.25M | bfloat16 |
+| [Doge-320M-Instruct-SFT](https://huggingface.co/SmallDoge/Doge-320M-Instruct-SFT) | [smoltalk](https://huggingface.co/datasets/HuggingFaceTB/smoltalk) | 2 | 2048 | 2e-4 | 0.25M | bfloat16 |
+
+**DPO**:
+| Model | Training Data | Epochs | Content Length | LR | Batch Size | Precision |
+|---|---|---|---|---|---|---|
+| [Doge-20M-Instruct](https://huggingface.co/SmallDoge/Doge-20M-Instruct) | [ultrafeedback_binarized](https://huggingface.co/datasets/HuggingFaceH4/ultrafeedback_binarized) | 2 | 1024 | 8e-5 | 0.125M | bfloat16 |
+| [Doge-20M-MoE-Instruct](https://huggingface.co/SmallDoge/Doge-20M-MoE-Instruct) | [ultrafeedback_binarized](https://huggingface.co/datasets/HuggingFaceH4/ultrafeedback_binarized) | 2 | 1024 | 8e-5 | 0.125M | bfloat16 |
+| [Doge-60M-Instruct](https://huggingface.co/SmallDoge/Doge-60M-Instruct) | [ultrafeedback_binarized](https://huggingface.co/datasets/HuggingFaceH4/ultrafeedback_binarized) | 2 | 1024 | 6e-5 | 0.125M | bfloat16 |
+| [Doge-120M-MoE-Instruct](https://huggingface.co/SmallDoge/Doge-120M-MoE-Instruct) | [ultrafeedback_binarized](https://huggingface.co/datasets/HuggingFaceH4/ultrafeedback_binarized) | 2 | 1024 | 6e-5 | 0.125M | bfloat16 |
+| [Doge-160M-Instruct](https://huggingface.co/SmallDoge/Doge-160M-Instruct) | [ultrafeedback_binarized](https://huggingface.co/datasets/HuggingFaceH4/ultrafeedback_binarized) | 2 | 1024 | 4e-5 | 0.125M | bfloat16 |
+| [Doge-320M-Instruct](https://huggingface.co/SmallDoge/Doge-320M-Instruct) | [ultrafeedback_binarized](https://huggingface.co/datasets/HuggingFaceH4/ultrafeedback_binarized) | 2 | 1024 | 2e-5 | 0.125M | bfloat16 |
+
+
+**Evaluation**:
+
+| Model | IFEval (Prompt Strict Acc) | MMLU | BBH | ARC | PIQA | HellaSwag | tokens / s on i7-11 CPU |
+|---|---|---|---|---|---|---|---|
+| [Doge-20M-Instruct](https://huggingface.co/SmallDoge/Doge-20M-Instruct) | 9.2 | 26.3 | 18.3 | 29.2 | 57.8 | 27.8 | 142 |
+| [Doge-20M-MoE-Instruct](https://huggingface.co/SmallDoge/Doge-20M-MoE-Instruct) | 13.7 | 26.5 | 26.3 | 31.1 | 58.2 | 27.9 | 132 |
+| [Doge-60M-Instruct](https://huggingface.co/SmallDoge/Doge-60M-Instruct) | 9.4 | 27.5 | 27.7 | 37.5 | 61.4 | 32.1 | 62 |
+| [Doge-120M-MoE-Instruct](https://huggingface.co/SmallDoge/Doge-120M-MoE-Instruct) | 24.4 | 28.2 | 30.1 | 44.2 | 62.1 | 36.3 | 58 |
+| [Doge-160M-Instruct](https://huggingface.co/SmallDoge/Doge-160M-Instruct) | 16.8 | 29.7 | 29.1 | 42.8 | 64.1 | 37.1 | 28 |
+| [Doge-320M-Instruct](https://huggingface.co/SmallDoge/Doge-320M-Instruct) | 28.5 | 30.3 | 31.9 | 51.7 | 71.0 | 50.6 | 16 |
+
+
+**Procedure**:
+
+**SFT**:
+[<img src="https://raw.githubusercontent.com/wandb/assets/main/wandb-github-badge-28.svg" alt="Visualize in Weights & Biases" width="150" height="24"/>](https://wandb.ai/loser_cheems/huggingface/runs/eohr6fuj) 
+
+**DPO**:
+[<img src="https://raw.githubusercontent.com/wandb/assets/main/wandb-github-badge-28.svg" alt="Visualize in Weights & Biases" width="150" height="24"/>](https://wandb.ai/loser_cheems/huggingface/runs/h6c2p2fe)
+
+
+**Environment**:
+- Image: nvcr.io/nvidia/pytorch:24.12-py3
+- Hardware: 1x NVIDIA RTX 4090
+- Software: Transformers, TRL
+
+
+## Citation
+
+```bibtex
+@misc{smalldoges,
+  title={SmallDoges: A Family of Dynamic UltraFast Small Language Models}, 
+  author={Jingze, Shi and Yifan, Wu and Bingheng, Wu and Yuyu, Luo},
+  year={2025},
+  month={March},
+  url={https://github.com/SmallDoges/small-doge}
+}
+```

--- a/docs/Doge-20M.md
+++ b/docs/Doge-20M.md
@@ -1,0 +1,96 @@
+---
+library_name: transformers
+license: apache-2.0
+datasets:
+- HuggingFaceTB/smollm-corpus
+language:
+- en
+pipeline_tag: text-generation
+tags:
+- pt
+- doge
+---
+
+
+# **Doge 20M**
+
+<div align="center">
+  <img src="https://huggingface.co/spaces/SmallDoge/README/resolve/main/org_icon.png" width="100%" alt="SmallDoge" />
+</div>
+<hr>
+<div align="center">
+  <a href="https://discord.gg/P2yYH95N" target="_blank" style="margin: 2px;">
+    <img alt="Discord" src="https://img.shields.io/badge/Discord-Small%20Doges-7289da?logo=discord&logoColor=white&color=7289da" style="display: inline-block; vertical-align: middle;"/>
+  </a>
+  <!-- <a href="https://arxiv.org/abs/2412.11834" target="_blank" style="margin: 2px;">
+    <img alt="arXiv" src="https://img.shields.io/static/v1?label=arXiv&message=2412.11834&color=B31B1B&logo=arXiv" style="display: inline-block; vertical-align: middle;"/>
+  </a> -->
+  <a href="https://github.com/SmallDoges/small-doge" target="_blank" style="margin: 2px;">
+    <img alt="GitHub" src="https://img.shields.io/badge/GitHub-SmallDoge-181717?logo=github" style="display: inline-block; vertical-align: middle;"/>
+  </a>
+  <a href="https://github.com/SmallDoges/small-doge/blob/main/LICENSE" style="margin: 2px;">
+    <img alt="License" src="https://img.shields.io/badge/License-Apache--2.0-blue.svg" style="display: inline-block; vertical-align: middle;"/>
+  </a>
+</div>
+
+Doge uses Dynamic Mask Attention as sequence transformation and can use Multi-Layer Perceptron or Cross Domain Mixture of Experts as state transformation. Dynamic Mask Attention allows the Transformer to use self-attention during training and state space during inference, and Cross Domain Mixture of Experts can directly inherit the weights of Multi-Layer Perceptron for further training. This model is trained by [SmallDoge](https://huggingface.co/SmallDoge) community, for detailed algorithm and model architecture, paper coming soon, all training details and code are available in the [small-doge](https://github.com/SmallDoges/small-doge) repository.
+
+## Uses
+
+```python
+>>> from transformers import AutoTokenizer, AutoModelForCausalLM
+
+>>> tokenizer = AutoTokenizer.from_pretrained("SmallDoge/Doge-20M")
+>>> model = AutoModelForCausalLM.from_pretrained("SmallDoge/Doge-20M", trust_remote_code=True)
+>>> inputs = tokenizer("Hey how are you doing?", return_tensors="pt")
+
+>>> out = model.generate(**inputs, max_new_tokens=100)
+>>> print(tokenizer.batch_decode(out))
+```
+
+
+## Model Details
+
+We build the Doge by doing Per-Training on [Smollm-Corpus](https://huggingface.co/datasets/HuggingFaceTB/smollm-corpus). If you want to continue pre-training this model, you can find the unconverged checkpoint [here](https://huggingface.co/SmallDoge/Doge-60M-checkpoint). These models has not been fine-tuned for instruction, the instruction model is [here](https://huggingface.co/SmallDoge/Doge-60M-Instruct).
+
+
+**Pre-Training**:
+
+| Model | Training Data | Steps | Content Length | Tokens | LR | Batch Size | Precision | RTX 4090 GPU hours |
+|---|---|---|---|---|---|---|---|---|
+| [Doge-20M](https://huggingface.co/SmallDoge/Doge-20M) | [smollm-corpus](https://huggingface.co/datasets/HuggingFaceTB/smollm-corpus) | 8k  | 2048 | 4B | 8e-3 | 0.5M | bfloat16 | 14 |
+| [Doge-60M](https://huggingface.co/SmallDoge/Doge-60M) | [smollm-corpus](https://huggingface.co/datasets/HuggingFaceTB/smollm-corpus) | 16k  | 2048 | 16B | 6e-3 | 1M | bfloat16 | 128 |
+| [Doge-160M](https://huggingface.co/SmallDoge/Doge-160M) | [smollm-corpus](https://huggingface.co/datasets/HuggingFaceTB/smollm-corpus) | 24k  | 2048 | 32B | 4e-3 | 1.5M | bfloat16 | 522 |
+| [Doge-320M](https://huggingface.co/SmallDoge/Doge-320M) | [smollm-corpus](https://huggingface.co/datasets/HuggingFaceTB/smollm-corpus) | 32k  | 2048 | 64B | 2e-3 | 2M | bfloat16 | 1856 |
+
+**Evaluation**:
+
+| Model | MMLU | TriviaQA | ARC | PIQA | HellaSwag | OBQA | Winogrande | tokens / s on i7-11 CPU |
+|---|---|---|---|---|---|---|---|---|
+| [Doge-20M](https://huggingface.co/SmallDoge/Doge-20M) | 25.4 | 0.03 | 29.8 | 58.4 | 27.3 | 25.6 | 50.2 | 142 |
+| [Doge-60M](https://huggingface.co/SmallDoge/Doge-60M) | 26.4 | 0.2 | 37.9 | 61.4 | 31.5 | 28.0 | 50.8 | 62 |
+| [Doge-160M](https://huggingface.co/SmallDoge/Doge-160M) | 29.2 | 4.8 | 44.4 | 70.1 | 43.4 | 34.4 | 52.2 | 28 |
+| [Doge-320M](https://huggingface.co/SmallDoge/Doge-320M) | 35.6 | 9.4 | 55.4 | 73.9 | 52.7 | 37.9 | 59.3 | 16 |
+
+**Procedure**:
+
+[<img src="https://raw.githubusercontent.com/wandb/assets/main/wandb-github-badge-28.svg" alt="Visualize in Weights & Biases" width="150" height="24"/>](https://wandb.ai/loser_cheems/huggingface/runs/p8x93v5l) 
+
+**Environment**:
+
+- Image: nvcr.io/nvidia/pytorch:24.12-py3
+- Hardware: 1x NVIDIA RTX 4090
+- Software: Transformers
+
+
+## Citation
+
+```bibtex
+@misc{smalldoges,
+  title={SmallDoges: A Family of Dynamic UltraFast Small Language Models}, 
+  author={Jingze, Shi and Yifan, Wu and Bingheng, Wu and Yuyu, Luo},
+  year={2025},
+  month={March},
+  url={https://github.com/SmallDoges/small-doge}
+}
+```

--- a/docs/Doge-320M-Instruct-SFT.md
+++ b/docs/Doge-320M-Instruct-SFT.md
@@ -1,0 +1,116 @@
+---
+library_name: transformers
+license: apache-2.0
+datasets:
+- HuggingFaceTB/smoltalk
+base_model:
+- SmallDoge/Doge-320M
+language:
+- en
+pipeline_tag: question-answering
+tags:
+- trl
+- sft
+- doge
+---
+
+
+# **Doge 320M Instruct SFT**
+
+<div align="center">
+  <img src="https://huggingface.co/spaces/SmallDoge/README/resolve/main/org_icon.png" width="100%" alt="SmallDoge" />
+</div>
+<hr>
+<div align="center">
+  <a href="https://discord.gg/P2yYH95N" target="_blank" style="margin: 2px;">
+    <img alt="Discord" src="https://img.shields.io/badge/Discord-Small%20Doges-7289da?logo=discord&logoColor=white&color=7289da" style="display: inline-block; vertical-align: middle;"/>
+  </a>
+  <!-- <a href="https://arxiv.org/abs/2412.11834" target="_blank" style="margin: 2px;">
+    <img alt="arXiv" src="https://img.shields.io/static/v1?label=arXiv&message=2412.11834&color=B31B1B&logo=arXiv" style="display: inline-block; vertical-align: middle;"/>
+  </a> -->
+  <a href="https://github.com/SmallDoges/small-doge" target="_blank" style="margin: 2px;">
+    <img alt="GitHub" src="https://img.shields.io/badge/GitHub-SmallDoge-181717?logo=github" style="display: inline-block; vertical-align: middle;"/>
+  </a>
+  <a href="https://github.com/SmallDoges/small-doge/blob/main/LICENSE" style="margin: 2px;">
+    <img alt="License" src="https://img.shields.io/badge/License-Apache--2.0-blue.svg" style="display: inline-block; vertical-align: middle;"/>
+  </a>
+</div>
+
+Doge uses Dynamic Mask Attention as sequence transformation and can use Multi-Layer Perceptron or Cross Domain Mixture of Experts as state transformation. Dynamic Mask Attention allows the Transformer to use self-attention during training and state space during inference, and Cross Domain Mixture of Experts can directly inherit the weights of Multi-Layer Perceptron for further training. This model is trained by [SmallDoge](https://huggingface.co/SmallDoge) community, for detailed algorithm and model architecture, paper coming soon, all training details and code are available in the [small-doge](https://github.com/SmallDoges/small-doge) repository.
+
+
+## Uses
+
+```python
+from transformers import AutoTokenizer, AutoModelForCausalLM, GenerationConfig, TextStreamer
+
+tokenizer = AutoTokenizer.from_pretrained("SmallDoge/Doge-320M-Instruct-SFT")
+model = AutoModelForCausalLM.from_pretrained("SmallDoge/Doge-320M-Instruct-SFT", trust_remote_code=True)
+
+generation_config = GenerationConfig(
+      max_new_tokens=100, 
+      use_cache=True, 
+      do_sample=True, 
+      temperature=0.8, 
+      top_p=0.9,
+      repetition_penalty=1.0
+)
+steamer = TextStreamer(
+      tokenizer=tokenizer, 
+      skip_prompt=True
+)
+
+prompt = "Hi, how are you doing today?"
+conversation = [
+      {"role": "user", "content": prompt}
+]
+inputs = tokenizer.apply_chat_template(
+    conversation=conversation,
+    tokenize=True,
+    return_tensors="pt",
+)
+
+outputs = model.generate(
+    inputs, 
+    tokenizer=tokenizer,
+    generation_config=generation_config, 
+    streamer=steamer
+)
+```
+
+
+## Model Details
+
+We build the Doge-Instruct-SFT by SFT on [SmolTalk](https://huggingface.co/datasets/HuggingFaceTB/smoltalk).
+
+**SFT**:
+| Model | Training Data | Epochs | Content Length | LR | Batch Size | Precision |
+|---|---|---|---|---|---|---|
+| [Doge-20M-Instruct-SFT](https://huggingface.co/SmallDoge/Doge-20M-Instruct-SFT) | [smoltalk](https://huggingface.co/datasets/HuggingFaceTB/smoltalk) | 2 | 2048 | 8e-4 | 0.25M | bfloat16 |
+| [Doge-60M-Instruct-SFT](https://huggingface.co/SmallDoge/Doge-60M-Instruct-SFT) | [smoltalk](https://huggingface.co/datasets/HuggingFaceTB/smoltalk) | 2 | 2048 | 6e-4 | 0.25M | bfloat16 |
+| [Doge-160M-Instruct-SFT](https://huggingface.co/SmallDoge/Doge-160M-Instruct-SFT) | [smoltalk](https://huggingface.co/datasets/HuggingFaceTB/smoltalk) | 2 | 2048 | 4e-4 | 0.25M | bfloat16 |
+| [Doge-320M-Instruct-SFT](https://huggingface.co/SmallDoge/Doge-320M-Instruct-SFT) | [smoltalk](https://huggingface.co/datasets/HuggingFaceTB/smoltalk) | 2 | 2048 | 2e-4 | 0.25M | bfloat16 |
+
+
+**Procedure**:
+
+**SFT**:
+[<img src="https://raw.githubusercontent.com/wandb/assets/main/wandb-github-badge-28.svg" alt="Visualize in Weights & Biases" width="150" height="24"/>](https://wandb.ai/loser_cheems/huggingface/runs/7fa1hndl) 
+
+**Environment**:
+- Image: nvcr.io/nvidia/pytorch:24.12-py3
+- Hardware: 1x NVIDIA RTX 4090
+- Software: Transformers, TRL
+
+
+## Citation
+
+```bibtex
+@misc{smalldoges,
+  title={SmallDoges: A Family of Dynamic UltraFast Small Language Models}, 
+  author={Jingze, Shi and Yifan, Wu and Bingheng, Wu and Yuyu, Luo},
+  year={2025},
+  month={March},
+  url={https://github.com/SmallDoges/small-doge}
+}
+```

--- a/docs/Doge-320M-Instruct.md
+++ b/docs/Doge-320M-Instruct.md
@@ -1,0 +1,146 @@
+---
+library_name: transformers
+license: apache-2.0
+datasets:
+- HuggingFaceTB/smoltalk
+- HuggingFaceH4/ultrafeedback_binarized
+base_model:
+- SmallDoge/Doge-320M
+language:
+- en
+pipeline_tag: question-answering
+tags:
+- trl
+- sft
+- dpo
+- doge
+---
+
+
+# **Doge 320M Instruct**
+
+<div align="center">
+  <img src="https://huggingface.co/spaces/SmallDoge/README/resolve/main/org_icon.png" width="100%" alt="SmallDoge" />
+</div>
+<hr>
+<div align="center">
+  <a href="https://discord.gg/P2yYH95N" target="_blank" style="margin: 2px;">
+    <img alt="Discord" src="https://img.shields.io/badge/Discord-Small%20Doges-7289da?logo=discord&logoColor=white&color=7289da" style="display: inline-block; vertical-align: middle;"/>
+  </a>
+  <!-- <a href="https://arxiv.org/abs/2412.11834" target="_blank" style="margin: 2px;">
+    <img alt="arXiv" src="https://img.shields.io/static/v1?label=arXiv&message=2412.11834&color=B31B1B&logo=arXiv" style="display: inline-block; vertical-align: middle;"/>
+  </a> -->
+  <a href="https://github.com/SmallDoges/small-doge" target="_blank" style="margin: 2px;">
+    <img alt="GitHub" src="https://img.shields.io/badge/GitHub-SmallDoge-181717?logo=github" style="display: inline-block; vertical-align: middle;"/>
+  </a>
+  <a href="https://github.com/SmallDoges/small-doge/blob/main/LICENSE" style="margin: 2px;">
+    <img alt="License" src="https://img.shields.io/badge/License-Apache--2.0-blue.svg" style="display: inline-block; vertical-align: middle;"/>
+  </a>
+</div>
+
+Doge uses Dynamic Mask Attention as sequence transformation and can use Multi-Layer Perceptron or Cross Domain Mixture of Experts as state transformation. Dynamic Mask Attention allows the Transformer to use self-attention during training and state space during inference, and Cross Domain Mixture of Experts can directly inherit the weights of Multi-Layer Perceptron for further training. This model is trained by [SmallDoge](https://huggingface.co/SmallDoge) community, for detailed algorithm and model architecture, paper coming soon, all training details and code are available in the [small-doge](https://github.com/SmallDoges/small-doge) repository.
+
+
+## Uses
+
+```python
+from transformers import AutoTokenizer, AutoModelForCausalLM, GenerationConfig, TextStreamer
+
+tokenizer = AutoTokenizer.from_pretrained("SmallDoge/Doge-320M-Instruct")
+model = AutoModelForCausalLM.from_pretrained("SmallDoge/Doge-320M-Instruct", trust_remote_code=True)
+
+generation_config = GenerationConfig(
+      max_new_tokens=100, 
+      use_cache=True, 
+      do_sample=True, 
+      temperature=0.8, 
+      top_p=0.9,
+      repetition_penalty=1.0
+)
+steamer = TextStreamer(
+      tokenizer=tokenizer, 
+      skip_prompt=True
+)
+
+prompt = "Hi, how are you doing today?"
+conversation = [
+      {"role": "user", "content": prompt}
+]
+inputs = tokenizer.apply_chat_template(
+    conversation=conversation,
+    tokenize=True,
+    return_tensors="pt",
+)
+
+outputs = model.generate(
+    inputs, 
+    tokenizer=tokenizer,
+    generation_config=generation_config, 
+    streamer=steamer
+)
+```
+
+
+## Model Details
+
+We build the Doge-Instruct by first SFT on [SmolTalk](https://huggingface.co/datasets/HuggingFaceTB/smoltalk) and then DPO on [UltraFeedback Binarized](https://huggingface.co/datasets/HuggingFaceH4/ultrafeedback_binarized).
+
+**SFT**:
+| Model | Training Data | Epochs | Content Length | LR | Batch Size | Precision |
+|---|---|---|---|---|---|---|
+| [Doge-20M-Instruct-SFT](https://huggingface.co/SmallDoge/Doge-20M-Instruct-SFT) | [smoltalk](https://huggingface.co/datasets/HuggingFaceTB/smoltalk) | 2 | 2048 | 8e-4 | 0.25M | bfloat16 |
+| [Doge-20M-MoE-Instruct-SFT](https://huggingface.co/SmallDoge/Doge-20M-MoE-Instruct-SFT) | [smoltalk](https://huggingface.co/datasets/HuggingFaceTB/smoltalk) | 2 | 2048 | 8e-4 | 0.25M | bfloat16 |
+| [Doge-60M-Instruct-SFT](https://huggingface.co/SmallDoge/Doge-60M-Instruct-SFT) | [smoltalk](https://huggingface.co/datasets/HuggingFaceTB/smoltalk) | 2 | 2048 | 6e-4 | 0.25M | bfloat16 |
+| [Doge-120M-MoE-Instruct-SFT](https://huggingface.co/SmallDoge/Doge-120M-MoE-Instruct-SFT) | [smoltalk](https://huggingface.co/datasets/HuggingFaceTB/smoltalk) | 2 | 2048 | 6e-4 | 0.25M | bfloat16 |
+| [Doge-160M-Instruct-SFT](https://huggingface.co/SmallDoge/Doge-160M-Instruct-SFT) | [smoltalk](https://huggingface.co/datasets/HuggingFaceTB/smoltalk) | 2 | 2048 | 4e-4 | 0.25M | bfloat16 |
+| [Doge-320M-Instruct-SFT](https://huggingface.co/SmallDoge/Doge-320M-Instruct-SFT) | [smoltalk](https://huggingface.co/datasets/HuggingFaceTB/smoltalk) | 2 | 2048 | 2e-4 | 0.25M | bfloat16 |
+
+**DPO**:
+| Model | Training Data | Epochs | Content Length | LR | Batch Size | Precision |
+|---|---|---|---|---|---|---|
+| [Doge-20M-Instruct](https://huggingface.co/SmallDoge/Doge-20M-Instruct) | [ultrafeedback_binarized](https://huggingface.co/datasets/HuggingFaceH4/ultrafeedback_binarized) | 2 | 1024 | 8e-5 | 0.125M | bfloat16 |
+| [Doge-20M-MoE-Instruct](https://huggingface.co/SmallDoge/Doge-20M-MoE-Instruct) | [ultrafeedback_binarized](https://huggingface.co/datasets/HuggingFaceH4/ultrafeedback_binarized) | 2 | 1024 | 8e-5 | 0.125M | bfloat16 |
+| [Doge-60M-Instruct](https://huggingface.co/SmallDoge/Doge-60M-Instruct) | [ultrafeedback_binarized](https://huggingface.co/datasets/HuggingFaceH4/ultrafeedback_binarized) | 2 | 1024 | 6e-5 | 0.125M | bfloat16 |
+| [Doge-120M-MoE-Instruct](https://huggingface.co/SmallDoge/Doge-120M-MoE-Instruct) | [ultrafeedback_binarized](https://huggingface.co/datasets/HuggingFaceH4/ultrafeedback_binarized) | 2 | 1024 | 6e-5 | 0.125M | bfloat16 |
+| [Doge-160M-Instruct](https://huggingface.co/SmallDoge/Doge-160M-Instruct) | [ultrafeedback_binarized](https://huggingface.co/datasets/HuggingFaceH4/ultrafeedback_binarized) | 2 | 1024 | 4e-5 | 0.125M | bfloat16 |
+| [Doge-320M-Instruct](https://huggingface.co/SmallDoge/Doge-320M-Instruct) | [ultrafeedback_binarized](https://huggingface.co/datasets/HuggingFaceH4/ultrafeedback_binarized) | 2 | 1024 | 2e-5 | 0.125M | bfloat16 |
+
+
+**Evaluation**:
+
+| Model | IFEval (Prompt Strict Acc) | MMLU | BBH | ARC | PIQA | HellaSwag | tokens / s on i7-11 CPU |
+|---|---|---|---|---|---|---|---|
+| [Doge-20M-Instruct](https://huggingface.co/SmallDoge/Doge-20M-Instruct) | 9.2 | 26.3 | 18.3 | 29.2 | 57.8 | 27.8 | 142 |
+| [Doge-20M-MoE-Instruct](https://huggingface.co/SmallDoge/Doge-20M-MoE-Instruct) | 13.7 | 26.5 | 26.3 | 31.1 | 58.2 | 27.9 | 132 |
+| [Doge-60M-Instruct](https://huggingface.co/SmallDoge/Doge-60M-Instruct) | 9.4 | 27.5 | 27.7 | 37.5 | 61.4 | 32.1 | 62 |
+| [Doge-120M-MoE-Instruct](https://huggingface.co/SmallDoge/Doge-120M-MoE-Instruct) | 24.4 | 28.2 | 30.1 | 44.2 | 62.1 | 36.3 | 58 |
+| [Doge-160M-Instruct](https://huggingface.co/SmallDoge/Doge-160M-Instruct) | 16.8 | 29.7 | 29.1 | 42.8 | 64.1 | 37.1 | 28 |
+| [Doge-320M-Instruct](https://huggingface.co/SmallDoge/Doge-320M-Instruct) | 28.5 | 30.3 | 31.9 | 51.7 | 71.0 | 50.6 | 16 |
+
+
+**Procedure**:
+
+**SFT**:
+[<img src="https://raw.githubusercontent.com/wandb/assets/main/wandb-github-badge-28.svg" alt="Visualize in Weights & Biases" width="150" height="24"/>](https://wandb.ai/loser_cheems/huggingface/runs/7fa1hndl) 
+
+**DPO**:
+[<img src="https://raw.githubusercontent.com/wandb/assets/main/wandb-github-badge-28.svg" alt="Visualize in Weights & Biases" width="150" height="24"/>](https://wandb.ai/loser_cheems/huggingface/runs/33nrnvgj)
+
+
+**Environment**:
+- Image: nvcr.io/nvidia/pytorch:24.12-py3
+- Hardware: 1x NVIDIA RTX 4090
+- Software: Transformers, TRL
+
+
+## Citation
+
+```bibtex
+@misc{smalldoges,
+  title={SmallDoges: A Family of Dynamic UltraFast Small Language Models}, 
+  author={Jingze, Shi and Yifan, Wu and Bingheng, Wu and Yuyu, Luo},
+  year={2025},
+  month={March},
+  url={https://github.com/SmallDoges/small-doge}
+}
+```

--- a/docs/Doge-320M.md
+++ b/docs/Doge-320M.md
@@ -1,0 +1,98 @@
+---
+library_name: transformers
+license: apache-2.0
+datasets:
+- HuggingFaceTB/smollm-corpus
+language:
+- en
+pipeline_tag: text-generation
+tags:
+- pt
+- doge
+---
+
+
+# **Doge 320M**
+
+<div align="center">
+  <img src="https://huggingface.co/spaces/SmallDoge/README/resolve/main/org_icon.png" width="100%" alt="SmallDoge" />
+</div>
+<hr>
+<div align="center">
+  <a href="https://discord.gg/P2yYH95N" target="_blank" style="margin: 2px;">
+    <img alt="Discord" src="https://img.shields.io/badge/Discord-Small%20Doges-7289da?logo=discord&logoColor=white&color=7289da" style="display: inline-block; vertical-align: middle;"/>
+  </a>
+  <!-- <a href="https://arxiv.org/abs/2412.11834" target="_blank" style="margin: 2px;">
+    <img alt="arXiv" src="https://img.shields.io/static/v1?label=arXiv&message=2412.11834&color=B31B1B&logo=arXiv" style="display: inline-block; vertical-align: middle;"/>
+  </a> -->
+  <a href="https://github.com/SmallDoges/small-doge" target="_blank" style="margin: 2px;">
+    <img alt="GitHub" src="https://img.shields.io/badge/GitHub-SmallDoge-181717?logo=github" style="display: inline-block; vertical-align: middle;"/>
+  </a>
+  <a href="https://github.com/SmallDoges/small-doge/blob/main/LICENSE" style="margin: 2px;">
+    <img alt="License" src="https://img.shields.io/badge/License-Apache--2.0-blue.svg" style="display: inline-block; vertical-align: middle;"/>
+  </a>
+</div>
+
+
+Doge uses Dynamic Mask Attention as sequence transformation and can use Multi-Layer Perceptron or Cross Domain Mixture of Experts as state transformation. Dynamic Mask Attention allows the Transformer to use self-attention during training and state space during inference, and Cross Domain Mixture of Experts can directly inherit the weights of Multi-Layer Perceptron for further training. This model is trained by [SmallDoge](https://huggingface.co/SmallDoge) community, for detailed algorithm and model architecture, paper coming soon, all training details and code are available in the [small-doge](https://github.com/SmallDoges/small-doge) repository.
+
+
+## Uses
+
+```python
+>>> from transformers import AutoTokenizer, AutoModelForCausalLM
+
+>>> tokenizer = AutoTokenizer.from_pretrained("SmallDoge/Doge-320M")
+>>> model = AutoModelForCausalLM.from_pretrained("SmallDoge/Doge-320M", trust_remote_code=True)
+>>> inputs = tokenizer("Hey how are you doing?", return_tensors="pt")
+
+>>> out = model.generate(**inputs, max_new_tokens=100)
+>>> print(tokenizer.batch_decode(out))
+```
+
+
+## Model Details
+
+We build the Doge by doing Per-Training on [Smollm-Corpus](https://huggingface.co/datasets/HuggingFaceTB/smollm-corpus). If you want to continue pre-training this model, you can find the unconverged checkpoint [here](https://huggingface.co/SmallDoge/Doge-320M-checkpoint). These models has not been fine-tuned for instruction, the instruction model is [here](https://huggingface.co/SmallDoge/Doge-320M-Instruct).
+
+
+**Pre-Training**:
+
+| Model | Training Data | Steps | Content Length | Tokens | LR | Batch Size | Precision | RTX 4090 GPU hours |
+|---|---|---|---|---|---|---|---|---|
+| [Doge-20M](https://huggingface.co/SmallDoge/Doge-20M) | [smollm-corpus](https://huggingface.co/datasets/HuggingFaceTB/smollm-corpus) | 8k  | 2048 | 4B | 8e-3 | 0.5M | bfloat16 | 14 |
+| [Doge-60M](https://huggingface.co/SmallDoge/Doge-60M) | [smollm-corpus](https://huggingface.co/datasets/HuggingFaceTB/smollm-corpus) | 16k  | 2048 | 16B | 6e-3 | 1M | bfloat16 | 128 |
+| [Doge-160M](https://huggingface.co/SmallDoge/Doge-160M) | [smollm-corpus](https://huggingface.co/datasets/HuggingFaceTB/smollm-corpus) | 24k  | 2048 | 32B | 4e-3 | 1.5M | bfloat16 | 522 |
+| [Doge-320M](https://huggingface.co/SmallDoge/Doge-320M) | [smollm-corpus](https://huggingface.co/datasets/HuggingFaceTB/smollm-corpus) | 32k  | 2048 | 64B | 2e-3 | 2M | bfloat16 | 1856 |
+
+**Evaluation**:
+
+| Model | MMLU | TriviaQA | ARC | PIQA | HellaSwag | OBQA | Winogrande | tokens / s on i7-11 CPU |
+|---|---|---|---|---|---|---|---|---|
+| [Doge-20M](https://huggingface.co/SmallDoge/Doge-20M) | 25.4 | 0.03 | 29.8 | 58.4 | 27.3 | 25.6 | 50.2 | 142 |
+| [Doge-60M](https://huggingface.co/SmallDoge/Doge-60M) | 26.4 | 0.2 | 37.9 | 61.4 | 31.5 | 28.0 | 50.8 | 62 |
+| [Doge-160M](https://huggingface.co/SmallDoge/Doge-160M) | 29.2 | 4.8 | 44.4 | 70.1 | 43.4 | 34.4 | 52.2 | 28 |
+| [Doge-320M](https://huggingface.co/SmallDoge/Doge-320M) | 35.6 | 9.4 | 55.4 | 73.9 | 52.7 | 37.9 | 59.3 | 16 |
+
+**Procedure**:
+
+[<img src="https://raw.githubusercontent.com/wandb/assets/main/wandb-github-badge-28.svg" alt="Visualize in Weights & Biases" width="150" height="24"/>](https://wandb.ai/loser_cheems/huggingface/runs/y18ty3sh) 
+
+**Environment**:
+
+- Image: nvcr.io/nvidia/pytorch:24.12-py3
+- Hardware: 1x NVIDIA RTX 4090
+- Software: Transformers
+
+
+## Citation
+
+```bibtex
+@misc{smalldoges,
+  title={SmallDoges: A Family of Dynamic UltraFast Small Language Models}, 
+  author={Jingze, Shi and Yifan, Wu and Bingheng, Wu and Yuyu, Luo},
+  year={2025},
+  month={March},
+  url={https://github.com/SmallDoges/small-doge}
+}
+```

--- a/docs/Doge-60M-Instruct-SFT.md
+++ b/docs/Doge-60M-Instruct-SFT.md
@@ -1,0 +1,117 @@
+---
+library_name: transformers
+license: apache-2.0
+datasets:
+- HuggingFaceTB/smoltalk
+base_model:
+- SmallDoge/Doge-60M
+language:
+- en
+pipeline_tag: question-answering
+tags:
+- trl
+- sft
+- doge
+---
+
+
+# **Doge 60M Instruct SFT**
+
+<div align="center">
+  <img src="https://huggingface.co/spaces/SmallDoge/README/resolve/main/org_icon.png" width="100%" alt="SmallDoge" />
+</div>
+<hr>
+<div align="center">
+  <a href="https://discord.gg/P2yYH95N" target="_blank" style="margin: 2px;">
+    <img alt="Discord" src="https://img.shields.io/badge/Discord-Small%20Doges-7289da?logo=discord&logoColor=white&color=7289da" style="display: inline-block; vertical-align: middle;"/>
+  </a>
+  <!-- <a href="https://arxiv.org/abs/2412.11834" target="_blank" style="margin: 2px;">
+    <img alt="arXiv" src="https://img.shields.io/static/v1?label=arXiv&message=2412.11834&color=B31B1B&logo=arXiv" style="display: inline-block; vertical-align: middle;"/>
+  </a> -->
+  <a href="https://github.com/SmallDoges/small-doge" target="_blank" style="margin: 2px;">
+    <img alt="GitHub" src="https://img.shields.io/badge/GitHub-SmallDoge-181717?logo=github" style="display: inline-block; vertical-align: middle;"/>
+  </a>
+  <a href="https://github.com/SmallDoges/small-doge/blob/main/LICENSE" style="margin: 2px;">
+    <img alt="License" src="https://img.shields.io/badge/License-Apache--2.0-blue.svg" style="display: inline-block; vertical-align: middle;"/>
+  </a>
+</div>
+
+Doge uses Dynamic Mask Attention as sequence transformation and can use Multi-Layer Perceptron or Cross Domain Mixture of Experts as state transformation. Dynamic Mask Attention allows the Transformer to use self-attention during training and state space during inference, and Cross Domain Mixture of Experts can directly inherit the weights of Multi-Layer Perceptron for further training. This model is trained by [SmallDoge](https://huggingface.co/SmallDoge) community, for detailed algorithm and model architecture, paper coming soon, all training details and code are available in the [small-doge](https://github.com/SmallDoges/small-doge) repository.
+
+
+## Uses
+
+```python
+from transformers import AutoTokenizer, AutoModelForCausalLM, GenerationConfig, TextStreamer
+
+tokenizer = AutoTokenizer.from_pretrained("SmallDoge/Doge-60M-Instruct-SFT")
+model = AutoModelForCausalLM.from_pretrained("SmallDoge/Doge-60M-Instruct-SFT", trust_remote_code=True)
+
+generation_config = GenerationConfig(
+      max_new_tokens=100, 
+      use_cache=True, 
+      do_sample=True, 
+      temperature=0.8, 
+      top_p=0.9,
+      repetition_penalty=1.0
+)
+steamer = TextStreamer(
+      tokenizer=tokenizer, 
+      skip_prompt=True
+)
+
+prompt = "Hi, how are you doing today?"
+conversation = [
+      {"role": "user", "content": prompt}
+]
+inputs = tokenizer.apply_chat_template(
+    conversation=conversation,
+    tokenize=True,
+    return_tensors="pt",
+)
+
+outputs = model.generate(
+    inputs, 
+    tokenizer=tokenizer,
+    generation_config=generation_config, 
+    streamer=steamer
+)
+```
+
+
+## Model Details
+
+We build the Doge-Instruct-SFT by SFT on [SmolTalk](https://huggingface.co/datasets/HuggingFaceTB/smoltalk).
+
+**SFT**:
+| Model | Training Data | Epochs | Content Length | LR | Batch Size | Precision |
+|---|---|---|---|---|---|---|
+| [Doge-20M-Instruct-SFT](https://huggingface.co/SmallDoge/Doge-20M-Instruct-SFT) | [smoltalk](https://huggingface.co/datasets/HuggingFaceTB/smoltalk) | 2 | 2048 | 8e-4 | 0.25M | bfloat16 |
+| [Doge-60M-Instruct-SFT](https://huggingface.co/SmallDoge/Doge-60M-Instruct-SFT) | [smoltalk](https://huggingface.co/datasets/HuggingFaceTB/smoltalk) | 2 | 2048 | 6e-4 | 0.25M | bfloat16 |
+| [Doge-160M-Instruct-SFT](https://huggingface.co/SmallDoge/Doge-160M-Instruct-SFT) | [smoltalk](https://huggingface.co/datasets/HuggingFaceTB/smoltalk) | 2 | 2048 | 4e-4 | 0.25M | bfloat16 |
+| [Doge-320M-Instruct-SFT](https://huggingface.co/SmallDoge/Doge-320M-Instruct-SFT) | [smoltalk](https://huggingface.co/datasets/HuggingFaceTB/smoltalk) | 2 | 2048 | 2e-4 | 0.25M | bfloat16 |
+
+
+**Procedure**:
+
+**SFT**:
+[<img src="https://raw.githubusercontent.com/wandb/assets/main/wandb-github-badge-28.svg" alt="Visualize in Weights & Biases" width="150" height="24"/>](https://wandb.ai/loser_cheems/huggingface/runs/eohr6fuj) 
+
+
+**Environment**:
+- Image: nvcr.io/nvidia/pytorch:24.12-py3
+- Hardware: 1x NVIDIA RTX 4090
+- Software: Transformers, TRL
+
+
+## Citation
+
+```bibtex
+@misc{smalldoges,
+  title={SmallDoges: A Family of Dynamic UltraFast Small Language Models}, 
+  author={Jingze, Shi and Yifan, Wu and Bingheng, Wu and Yuyu, Luo},
+  year={2025},
+  month={March},
+  url={https://github.com/SmallDoges/small-doge}
+}
+```

--- a/docs/Doge-60M-Instruct.md
+++ b/docs/Doge-60M-Instruct.md
@@ -1,0 +1,146 @@
+---
+library_name: transformers
+license: apache-2.0
+datasets:
+- HuggingFaceTB/smoltalk
+- HuggingFaceH4/ultrafeedback_binarized
+base_model:
+- SmallDoge/Doge-60M
+language:
+- en
+pipeline_tag: question-answering
+tags:
+- trl
+- sft
+- dpo
+- doge
+---
+
+
+# **Doge 60M Instruct**
+
+<div align="center">
+  <img src="https://huggingface.co/spaces/SmallDoge/README/resolve/main/org_icon.png" width="100%" alt="SmallDoge" />
+</div>
+<hr>
+<div align="center">
+  <a href="https://discord.gg/P2yYH95N" target="_blank" style="margin: 2px;">
+    <img alt="Discord" src="https://img.shields.io/badge/Discord-Small%20Doges-7289da?logo=discord&logoColor=white&color=7289da" style="display: inline-block; vertical-align: middle;"/>
+  </a>
+  <!-- <a href="https://arxiv.org/abs/2412.11834" target="_blank" style="margin: 2px;">
+    <img alt="arXiv" src="https://img.shields.io/static/v1?label=arXiv&message=2412.11834&color=B31B1B&logo=arXiv" style="display: inline-block; vertical-align: middle;"/>
+  </a> -->
+  <a href="https://github.com/SmallDoges/small-doge" target="_blank" style="margin: 2px;">
+    <img alt="GitHub" src="https://img.shields.io/badge/GitHub-SmallDoge-181717?logo=github" style="display: inline-block; vertical-align: middle;"/>
+  </a>
+  <a href="https://github.com/SmallDoges/small-doge/blob/main/LICENSE" style="margin: 2px;">
+    <img alt="License" src="https://img.shields.io/badge/License-Apache--2.0-blue.svg" style="display: inline-block; vertical-align: middle;"/>
+  </a>
+</div>
+
+Doge uses Dynamic Mask Attention as sequence transformation and can use Multi-Layer Perceptron or Cross Domain Mixture of Experts as state transformation. Dynamic Mask Attention allows the Transformer to use self-attention during training and state space during inference, and Cross Domain Mixture of Experts can directly inherit the weights of Multi-Layer Perceptron for further training. This model is trained by [SmallDoge](https://huggingface.co/SmallDoge) community, for detailed algorithm and model architecture, paper coming soon, all training details and code are available in the [small-doge](https://github.com/SmallDoges/small-doge) repository.
+
+
+## Uses
+
+```python
+from transformers import AutoTokenizer, AutoModelForCausalLM, GenerationConfig, TextStreamer
+
+tokenizer = AutoTokenizer.from_pretrained("SmallDoge/Doge-60M-Instruct")
+model = AutoModelForCausalLM.from_pretrained("SmallDoge/Doge-60M-Instruct", trust_remote_code=True)
+
+generation_config = GenerationConfig(
+      max_new_tokens=100, 
+      use_cache=True, 
+      do_sample=True, 
+      temperature=0.8, 
+      top_p=0.9,
+      repetition_penalty=1.0
+)
+steamer = TextStreamer(
+      tokenizer=tokenizer, 
+      skip_prompt=True
+)
+
+prompt = "Hi, how are you doing today?"
+conversation = [
+      {"role": "user", "content": prompt}
+]
+inputs = tokenizer.apply_chat_template(
+    conversation=conversation,
+    tokenize=True,
+    return_tensors="pt",
+)
+
+outputs = model.generate(
+    inputs, 
+    tokenizer=tokenizer,
+    generation_config=generation_config, 
+    streamer=steamer
+)
+```
+
+
+## Model Details
+
+We build the Doge-Instruct by first SFT on [SmolTalk](https://huggingface.co/datasets/HuggingFaceTB/smoltalk) and then DPO on [UltraFeedback Binarized](https://huggingface.co/datasets/HuggingFaceH4/ultrafeedback_binarized).
+
+**SFT**:
+| Model | Training Data | Epochs | Content Length | LR | Batch Size | Precision |
+|---|---|---|---|---|---|---|
+| [Doge-20M-Instruct-SFT](https://huggingface.co/SmallDoge/Doge-20M-Instruct-SFT) | [smoltalk](https://huggingface.co/datasets/HuggingFaceTB/smoltalk) | 2 | 2048 | 8e-4 | 0.25M | bfloat16 |
+| [Doge-20M-MoE-Instruct-SFT](https://huggingface.co/SmallDoge/Doge-20M-MoE-Instruct-SFT) | [smoltalk](https://huggingface.co/datasets/HuggingFaceTB/smoltalk) | 2 | 2048 | 8e-4 | 0.25M | bfloat16 |
+| [Doge-60M-Instruct-SFT](https://huggingface.co/SmallDoge/Doge-60M-Instruct-SFT) | [smoltalk](https://huggingface.co/datasets/HuggingFaceTB/smoltalk) | 2 | 2048 | 6e-4 | 0.25M | bfloat16 |
+| [Doge-120M-MoE-Instruct-SFT](https://huggingface.co/SmallDoge/Doge-120M-MoE-Instruct-SFT) | [smoltalk](https://huggingface.co/datasets/HuggingFaceTB/smoltalk) | 2 | 2048 | 6e-4 | 0.25M | bfloat16 |
+| [Doge-160M-Instruct-SFT](https://huggingface.co/SmallDoge/Doge-160M-Instruct-SFT) | [smoltalk](https://huggingface.co/datasets/HuggingFaceTB/smoltalk) | 2 | 2048 | 4e-4 | 0.25M | bfloat16 |
+| [Doge-320M-Instruct-SFT](https://huggingface.co/SmallDoge/Doge-320M-Instruct-SFT) | [smoltalk](https://huggingface.co/datasets/HuggingFaceTB/smoltalk) | 2 | 2048 | 2e-4 | 0.25M | bfloat16 |
+
+**DPO**:
+| Model | Training Data | Epochs | Content Length | LR | Batch Size | Precision |
+|---|---|---|---|---|---|---|
+| [Doge-20M-Instruct](https://huggingface.co/SmallDoge/Doge-20M-Instruct) | [ultrafeedback_binarized](https://huggingface.co/datasets/HuggingFaceH4/ultrafeedback_binarized) | 2 | 1024 | 8e-5 | 0.125M | bfloat16 |
+| [Doge-20M-MoE-Instruct](https://huggingface.co/SmallDoge/Doge-20M-MoE-Instruct) | [ultrafeedback_binarized](https://huggingface.co/datasets/HuggingFaceH4/ultrafeedback_binarized) | 2 | 1024 | 8e-5 | 0.125M | bfloat16 |
+| [Doge-60M-Instruct](https://huggingface.co/SmallDoge/Doge-60M-Instruct) | [ultrafeedback_binarized](https://huggingface.co/datasets/HuggingFaceH4/ultrafeedback_binarized) | 2 | 1024 | 6e-5 | 0.125M | bfloat16 |
+| [Doge-120M-MoE-Instruct](https://huggingface.co/SmallDoge/Doge-120M-MoE-Instruct) | [ultrafeedback_binarized](https://huggingface.co/datasets/HuggingFaceH4/ultrafeedback_binarized) | 2 | 1024 | 6e-5 | 0.125M | bfloat16 |
+| [Doge-160M-Instruct](https://huggingface.co/SmallDoge/Doge-160M-Instruct) | [ultrafeedback_binarized](https://huggingface.co/datasets/HuggingFaceH4/ultrafeedback_binarized) | 2 | 1024 | 4e-5 | 0.125M | bfloat16 |
+| [Doge-320M-Instruct](https://huggingface.co/SmallDoge/Doge-320M-Instruct) | [ultrafeedback_binarized](https://huggingface.co/datasets/HuggingFaceH4/ultrafeedback_binarized) | 2 | 1024 | 2e-5 | 0.125M | bfloat16 |
+
+
+**Evaluation**:
+
+| Model | IFEval (Prompt Strict Acc) | MMLU | BBH | ARC | PIQA | HellaSwag | tokens / s on i7-11 CPU |
+|---|---|---|---|---|---|---|---|
+| [Doge-20M-Instruct](https://huggingface.co/SmallDoge/Doge-20M-Instruct) | 9.2 | 26.3 | 18.3 | 29.2 | 57.8 | 27.8 | 142 |
+| [Doge-20M-MoE-Instruct](https://huggingface.co/SmallDoge/Doge-20M-MoE-Instruct) | 13.7 | 26.5 | 26.3 | 31.1 | 58.2 | 27.9 | 132 |
+| [Doge-60M-Instruct](https://huggingface.co/SmallDoge/Doge-60M-Instruct) | 9.4 | 27.5 | 27.7 | 37.5 | 61.4 | 32.1 | 62 |
+| [Doge-120M-MoE-Instruct](https://huggingface.co/SmallDoge/Doge-120M-MoE-Instruct) | 24.4 | 28.2 | 30.1 | 44.2 | 62.1 | 36.3 | 58 |
+| [Doge-160M-Instruct](https://huggingface.co/SmallDoge/Doge-160M-Instruct) | 16.8 | 29.7 | 29.1 | 42.8 | 64.1 | 37.1 | 28 |
+| [Doge-320M-Instruct](https://huggingface.co/SmallDoge/Doge-320M-Instruct) | 28.5 | 30.3 | 31.9 | 51.7 | 71.0 | 50.6 | 16 |
+
+
+**Procedure**:
+
+**SFT**:
+[<img src="https://raw.githubusercontent.com/wandb/assets/main/wandb-github-badge-28.svg" alt="Visualize in Weights & Biases" width="150" height="24"/>](https://wandb.ai/loser_cheems/huggingface/runs/ckbn4b5m) 
+
+**DPO**:
+[<img src="https://raw.githubusercontent.com/wandb/assets/main/wandb-github-badge-28.svg" alt="Visualize in Weights & Biases" width="150" height="24"/>](https://wandb.ai/loser_cheems/huggingface/runs/3nk7mu5a)
+
+
+**Environment**:
+- Image: nvcr.io/nvidia/pytorch:24.12-py3
+- Hardware: 1x NVIDIA RTX 4090
+- Software: Transformers, TRL
+
+
+## Citation
+
+```bibtex
+@misc{smalldoges,
+  title={SmallDoges: A Family of Dynamic UltraFast Small Language Models}, 
+  author={Jingze, Shi and Yifan, Wu and Bingheng, Wu and Yuyu, Luo},
+  year={2025},
+  month={March},
+  url={https://github.com/SmallDoges/small-doge}
+}
+```

--- a/docs/Doge-60M.md
+++ b/docs/Doge-60M.md
@@ -1,0 +1,97 @@
+---
+library_name: transformers
+license: apache-2.0
+datasets:
+- HuggingFaceTB/smollm-corpus
+language:
+- en
+pipeline_tag: text-generation
+tags:
+- pt
+- doge
+---
+
+
+# **Doge 60M**
+
+<div align="center">
+  <img src="https://huggingface.co/spaces/SmallDoge/README/resolve/main/org_icon.png" width="100%" alt="SmallDoge" />
+</div>
+<hr>
+<div align="center">
+  <a href="https://discord.gg/P2yYH95N" target="_blank" style="margin: 2px;">
+    <img alt="Discord" src="https://img.shields.io/badge/Discord-Small%20Doges-7289da?logo=discord&logoColor=white&color=7289da" style="display: inline-block; vertical-align: middle;"/>
+  </a>
+  <!-- <a href="https://arxiv.org/abs/2412.11834" target="_blank" style="margin: 2px;">
+    <img alt="arXiv" src="https://img.shields.io/static/v1?label=arXiv&message=2412.11834&color=B31B1B&logo=arXiv" style="display: inline-block; vertical-align: middle;"/>
+  </a> -->
+  <a href="https://github.com/SmallDoges/small-doge" target="_blank" style="margin: 2px;">
+    <img alt="GitHub" src="https://img.shields.io/badge/GitHub-SmallDoge-181717?logo=github" style="display: inline-block; vertical-align: middle;"/>
+  </a>
+  <a href="https://github.com/SmallDoges/small-doge/blob/main/LICENSE" style="margin: 2px;">
+    <img alt="License" src="https://img.shields.io/badge/License-Apache--2.0-blue.svg" style="display: inline-block; vertical-align: middle;"/>
+  </a>
+</div>
+
+Doge uses Dynamic Mask Attention as sequence transformation and can use Multi-Layer Perceptron or Cross Domain Mixture of Experts as state transformation. Dynamic Mask Attention allows the Transformer to use self-attention during training and state space during inference, and Cross Domain Mixture of Experts can directly inherit the weights of Multi-Layer Perceptron for further training. This model is trained by [SmallDoge](https://huggingface.co/SmallDoge) community, for detailed algorithm and model architecture, paper coming soon, all training details and code are available in the [small-doge](https://github.com/SmallDoges/small-doge) repository.
+
+
+## Uses
+
+```python
+>>> from transformers import AutoTokenizer, AutoModelForCausalLM
+
+>>> tokenizer = AutoTokenizer.from_pretrained("SmallDoge/Doge-60M")
+>>> model = AutoModelForCausalLM.from_pretrained("SmallDoge/Doge-60M", trust_remote_code=True)
+>>> inputs = tokenizer("Hey how are you doing?", return_tensors="pt")
+
+>>> out = model.generate(**inputs, max_new_tokens=100)
+>>> print(tokenizer.batch_decode(out))
+```
+
+
+## Model Details
+
+We build the Doge by doing Per-Training on [Smollm-Corpus](https://huggingface.co/datasets/HuggingFaceTB/smollm-corpus). If you want to continue pre-training this model, you can find the unconverged checkpoint [here](https://huggingface.co/SmallDoge/Doge-60M-checkpoint). These models has not been fine-tuned for instruction, the instruction model is [here](https://huggingface.co/SmallDoge/Doge-60M-Instruct).
+
+
+**Pre-Training**:
+
+| Model | Training Data | Steps | Content Length | Tokens | LR | Batch Size | Precision | RTX 4090 GPU hours |
+|---|---|---|---|---|---|---|---|---|
+| [Doge-20M](https://huggingface.co/SmallDoge/Doge-20M) | [smollm-corpus](https://huggingface.co/datasets/HuggingFaceTB/smollm-corpus) | 8k  | 2048 | 4B | 8e-3 | 0.5M | bfloat16 | 14 |
+| [Doge-60M](https://huggingface.co/SmallDoge/Doge-60M) | [smollm-corpus](https://huggingface.co/datasets/HuggingFaceTB/smollm-corpus) | 16k  | 2048 | 16B | 6e-3 | 1M | bfloat16 | 128 |
+| [Doge-160M](https://huggingface.co/SmallDoge/Doge-160M) | [smollm-corpus](https://huggingface.co/datasets/HuggingFaceTB/smollm-corpus) | 24k  | 2048 | 32B | 4e-3 | 1.5M | bfloat16 | 522 |
+| [Doge-320M](https://huggingface.co/SmallDoge/Doge-320M) | [smollm-corpus](https://huggingface.co/datasets/HuggingFaceTB/smollm-corpus) | 32k  | 2048 | 64B | 2e-3 | 2M | bfloat16 | 1856 |
+
+**Evaluation**:
+
+| Model | MMLU | TriviaQA | ARC | PIQA | HellaSwag | OBQA | Winogrande | tokens / s on i7-11 CPU |
+|---|---|---|---|---|---|---|---|---|
+| [Doge-20M](https://huggingface.co/SmallDoge/Doge-20M) | 25.4 | 0.03 | 29.8 | 58.4 | 27.3 | 25.6 | 50.2 | 142 |
+| [Doge-60M](https://huggingface.co/SmallDoge/Doge-60M) | 26.4 | 0.2 | 37.9 | 61.4 | 31.5 | 28.0 | 50.8 | 62 |
+| [Doge-160M](https://huggingface.co/SmallDoge/Doge-160M) | 29.2 | 4.8 | 44.4 | 70.1 | 43.4 | 34.4 | 52.2 | 28 |
+| [Doge-320M](https://huggingface.co/SmallDoge/Doge-320M) | 35.6 | 9.4 | 55.4 | 73.9 | 52.7 | 37.9 | 59.3 | 16 |
+
+**Procedure**:
+
+[<img src="https://raw.githubusercontent.com/wandb/assets/main/wandb-github-badge-28.svg" alt="Visualize in Weights & Biases" width="150" height="24"/>](https://wandb.ai/loser_cheems/huggingface/runs/ydynuvfz) 
+
+**Environment**:
+
+- Image: nvcr.io/nvidia/pytorch:24.12-py3
+- Hardware: 1x NVIDIA RTX 4090
+- Software: Transformers
+
+
+## Citation
+
+```bibtex
+@misc{smalldoges,
+  title={SmallDoges: A Family of Dynamic UltraFast Small Language Models}, 
+  author={Jingze, Shi and Yifan, Wu and Bingheng, Wu and Yuyu, Luo},
+  year={2025},
+  month={March},
+  url={https://github.com/SmallDoges/small-doge}
+}
+```

--- a/docs/Doge-tokenizer.md
+++ b/docs/Doge-tokenizer.md
@@ -1,0 +1,323 @@
+---
+library_name: transformers
+datasets:
+- HuggingFaceTB/smollm-corpus
+---
+
+# Doge-tokenizer
+ Tokenizer for the training model on [smollm-corpus](https://huggingface.co/datasets/HuggingFaceTB/smollm-corpus), and support reasoning fine-tuning like R1.
+This tokenizer was trained on 2M samples from:
+ - FineWeb-Edu 70%
+ - Cosmopedia v2 20%
+ - Python-Edu  5%
+ - FineMath 5%
+
+## How to use
+
+<details>
+<summary>Only conversation</summary>
+
+```python
+from transformers import AutoTokenizer
+
+tokenizer = AutoTokenizer.from_pretrained("SmallDoge/Doge-tokenizer")
+
+conversation = [
+    {"role": "system", "content": "You are a helpful assistant."},
+    {"role": "user", "content": "What's wrong with Cheems? What treatment does he need?"},
+    {"role": "assistant", "content": "Based on Cheems' symptoms, I recommend the following treatment: For Cheems with severe kidney deficiency, it is recommended to eat more leeks and oysters."},
+]
+
+inputs = tokenizer.apply_chat_template(
+    conversation=conversation,
+    tokenize=False,
+)
+print(inputs)
+```
+```shell
+<|begin_of_text|><|start_header_id|>system<|end_header_id|>
+Cutting Knowledge Date: December 2024
+Today Date: December 2025
+You are a helpful assistant.<|end_of_text|>
+
+<|start_header_id|>user<|end_header_id|>
+What's wrong with Cheems? What treatment does he need?<|end_of_text|>
+
+<|start_header_id|>assistant<|end_header_id|>
+Based on Cheems' symptoms, I recommend the following treatment: For Cheems with severe kidney deficiency, it is recommended to eat more leeks and oysters.<|end_of_text|>
+```
+</details>
+
+<details>
+<summary>With documents</summary>
+
+```python
+from transformers import AutoTokenizer
+
+tokenizer = AutoTokenizer.from_pretrained("SmallDoge/Doge-tokenizer")
+
+documents = [
+    {
+        "title": "Cheems's case",
+        "text": "Cheems is a 233-year-old alchemist, but he is very kidney deficient."
+    },
+]
+
+conversation = [
+    {"role": "system", "content": "You are a helpful assistant."},
+    {"role": "user", "content": "What's wrong with Cheems? What treatment does he need?"},
+    {"role": "assistant", "content": "Based on Cheems' symptoms, I recommend the following treatment: For Cheems with severe kidney deficiency, it is recommended to eat more leeks and oysters."},
+]
+
+inputs = tokenizer.apply_chat_template(
+    documents=documents,
+    conversation=conversation,
+    tokenize=False,
+)
+print(inputs)
+```
+```shell
+<|begin_of_text|><|start_header_id|>system<|end_header_id|>
+Cutting Knowledge Date: December 2024
+Today Date: December 2025
+You are a helpful assistant.<|end_of_text|>
+
+<|start_header_id|>user<|end_header_id|>
+Given the following documents, please use them to answer the user's question.
+
+Title: Cheems' case
+Content: Cheems is a 233-year-old alchemist, but he is very kidney deficient.
+
+If the documents don't contain relevant information, rely on your general knowledge but acknowledge when you're doing so.
+
+What's wrong with Cheems? What treatment does he need?<|end_of_text|>
+
+<|start_header_id|>assistant<|end_header_id|>
+Based on Cheems' symptoms, I recommend the following treatment: For Cheems with severe kidney deficiency, it is recommended to eat more leeks and oysters.<|end_of_text|>
+```
+</details>
+
+<details>
+<summary>With tools</summary>
+
+```python
+from transformers import AutoTokenizer
+
+tokenizer = AutoTokenizer.from_pretrained("SmallDoge/Doge-tokenizer")
+
+tools = [
+    {
+        "name": "recommend_treatment",
+        "description": "Treatment is recommended based on patient symptoms and diagnosis.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "diagnosis": {
+                    "type": "string",
+                    "description": "Patient diagnostic results"
+                },
+                "severity": {
+                    "type": "string",
+                    "enum": ["mild", "moderate", "severe"],
+                    "description": "Severity of the condition, can be mild, moderate, or severe."
+                }
+            },
+            "required": ["diagnosis", "severity"]
+        }
+    }
+]
+
+conversation = [
+    {"role": "system", "content": "You are a helpful assistant."},
+    {"role": "user", "content": "What's wrong with Cheems? What treatment does he need?"},
+    {"role": "assistant", "tool_calls": [
+        {
+            "id": "call_1",
+            "function": {
+                "name": "recommend_treatment",
+                "arguments": "{\"diagnosis\": \"Deficiency of kidney\", \"severity\": \"severe\"}"
+            }
+        }
+    ]},
+    {"role": "tool", "tool_call_id": "call_1", "content": "For Cheems with severe kidney deficiency, it is recommended to eat more leeks and oysters."},
+    {"role": "assistant", "content": "Based on Cheems' symptoms, I recommend the following treatment: For Cheems with severe kidney deficiency, it is recommended to eat more leeks and oysters."},
+]
+
+inputs = tokenizer.apply_chat_template(
+    tools=tools,
+    conversation=conversation,
+    tokenize=False,
+)
+print(inputs)
+```
+```shell
+<|begin_of_text|><|start_header_id|>system<|end_header_id|>
+Environment: ipython
+Cutting Knowledge Date: December 2024
+Today Date: December 2025
+You are a helpful assistant.<|end_of_text|>
+
+<|start_header_id|>user<|end_header_id|>
+Given the following functions, please respond with a JSON for a function call with its proper arguments that best answers the given prompt.
+
+{
+    "name": "recommend_treatment",
+    "description": "Treatment is recommended based on patient symptoms and diagnosis.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "diagnosis": {
+                "type": "string",
+                "description": "Patient diagnostic results"
+            },
+            "severity": {
+                "type": "string",
+                "enum": [
+                    "mild",
+                    "moderate",
+                    "severe"
+                ],
+                "description": "Severity of the condition, can be mild, moderate, or severe."
+            }
+        },
+        "required": [
+            "diagnosis",
+            "severity"
+        ]
+    }
+}
+
+Respond in the format {"name": function name, "parameters": dictionary of argument name and its value}. Do not use variables.
+
+What's wrong with Cheems? What treatment does he need?<|end_of_text|>
+
+<|start_header_id|>assistant<|end_header_id|>
+{"name": "recommend_treatment", "parameters": "{\"diagnosis\": \"Deficiency of kidney\", \"severity\": \"severe\"}"}<|end_of_text|>
+
+<|start_header_id|>ipython<|end_header_id|>
+"For Cheems with severe kidney deficiency, it is recommended to eat more leeks and oysters."<|end_of_text|>
+
+<|start_header_id|>assistant<|end_header_id|>
+Based on Cheems' symptoms, I recommend the following treatment: For Cheems with severe kidney deficiency, it is recommended to eat more leeks and oysters.<|end_of_text|>
+```
+</details>
+
+<details>
+<summary>With documents and tools</summary>
+
+```python
+from transformers import AutoTokenizer
+
+tokenizer = AutoTokenizer.from_pretrained("SmallDoge/Doge-tokenizer")
+
+documents = [
+    {
+        "title": "Cheems's case",
+        "text": "Cheems is a 233-year-old alchemist, but he is very kidney deficient."
+    },
+]
+
+tools = [
+    {
+        "name": "recommend_treatment",
+        "description": "Treatment is recommended based on patient symptoms and diagnosis.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "diagnosis": {
+                    "type": "string",
+                    "description": "Patient diagnostic results"
+                },
+                "severity": {
+                    "type": "string",
+                    "enum": ["mild", "moderate", "severe"],
+                    "description": "Severity of the condition, can be mild, moderate, or severe."
+                }
+            },
+            "required": ["diagnosis", "severity"]
+        }
+    }
+]
+
+conversation = [
+    {"role": "system", "content": "You are a helpful assistant."},
+    {"role": "user", "content": "What's wrong with Cheems? What treatment does he need?"},
+    {"role": "assistant", "tool_calls": [
+        {
+            "id": "call_1",
+            "function": {
+                "name": "recommend_treatment",
+                "arguments": "{\"diagnosis\": \"Deficiency of kidney\", \"severity\": \"severe\"}"
+            }
+        }
+    ]},
+    {"role": "tool", "tool_call_id": "call_1", "content": "For Cheems with severe kidney deficiency, it is recommended to eat more leeks and oysters."},
+    {"role": "assistant", "content": "Based on Cheems' symptoms, I recommend the following treatment: For Cheems with severe kidney deficiency, it is recommended to eat more leeks and oysters."},
+]
+
+inputs = tokenizer.apply_chat_template(
+    documents=documents,
+    tools=tools,
+    conversation=conversation,
+    tokenize=False,
+)
+print(inputs)
+```
+```shell
+<|begin_of_text|><|start_header_id|>system<|end_header_id|>
+Environment: ipython
+Cutting Knowledge Date: December 2024
+Today Date: December 2025
+You are a helpful assistant.<|end_of_text|>
+
+<|start_header_id|>user<|end_header_id|>
+Given the following documents, please use them to answer the user's question.
+
+Title: Cheems' case
+Content: Cheems is a 233-year-old alchemist, but he is very kidney deficient.
+
+If the documents don't contain relevant information, rely on your general knowledge but acknowledge when you're doing so.
+
+Given the following functions, please respond with a JSON for a function call with its proper arguments that best answers the given prompt.
+
+{
+    "name": "recommend_treatment",
+    "description": "Treatment is recommended based on patient symptoms and diagnosis.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "diagnosis": {
+                "type": "string",
+                "description": "Patient diagnostic results"
+            },
+            "severity": {
+                "type": "string",
+                "enum": [
+                    "mild",
+                    "moderate",
+                    "severe"
+                ],
+                "description": "Severity of the condition, can be mild, moderate, or severe."
+            }
+        },
+        "required": [
+            "diagnosis",
+            "severity"
+        ]
+    }
+}
+
+Respond in the format {"name": function name, "parameters": dictionary of argument name and its value}. Do not use variables.
+
+What's wrong with Cheems? What treatment does he need?<|end_of_text|>
+
+<|start_header_id|>assistant<|end_header_id|>
+{"name": "recommend_treatment", "parameters": "{\"diagnosis\": \"Deficiency of kidney\", \"severity\": \"severe\"}"}<|end_of_text|>
+
+<|start_header_id|>ipython<|end_header_id|>
+"For Cheems with severe kidney deficiency, it is recommended to eat more leeks and oysters."<|end_of_text|>
+
+<|start_header_id|>assistant<|end_header_id|>
+Based on Cheems' symptoms, I recommend the following treatment: For Cheems with severe kidney deficiency, it is recommended to eat more leeks and oysters.<|end_of_text|>
+```
+</details>

--- a/docs/Doge2-tokenizer.md
+++ b/docs/Doge2-tokenizer.md
@@ -1,0 +1,309 @@
+---
+library_name: transformers
+datasets:
+- SmallDoge/SmallCorpus
+---
+
+# Doge2-tokenizer
+
+Tokenizer for the training model on [SmallCorpus](https://huggingface.co/datasets/SmallDoge/SmallCorpus), supporting document retrieval, tool invocation, and reasoning.
+This tokenizer was trained on 2M samples from:
+- Web-EN 50%
+- Web-ZH 20%
+- TextBook-EN 15%
+- TextBook-ZH 5%
+- Code 5%
+- Math 5%
+
+## How to use
+
+<details>
+<summary>Only conversation</summary>
+
+```python
+from transformers import AutoTokenizer
+
+tokenizer = AutoTokenizer.from_pretrained("SmallDoge/Doge2-tokenizer")
+
+conversation = [
+    {"role": "system", "content": "You are a helpful assistant."},
+    {"role": "user", "content": "What's wrong with Cheems? What treatment does he need?"},
+    {"role": "assistant", "content": "Based on Cheems' symptoms, I recommend the following treatment: For Cheems with severe kidney deficiency, it is recommended to eat more leeks and oysters."},
+]
+
+inputs = tokenizer.apply_chat_template(
+    conversation=conversation,
+    tokenize=False,
+)
+print(inputs)
+```
+```shell
+<|im_start|>system
+You are a helpful assistant.<|im_end|>
+<|im_start|>user
+What's wrong with Cheems? What treatment does he need?<|im_end|>
+<|im_start|>assistant
+<think>
+
+</think>
+
+Based on Cheems' symptoms, I recommend the following treatment: For Cheems with severe kidney deficiency, it is recommended to eat more leeks and oysters.<|im_end|>
+
+```
+</details>
+
+<details>
+<summary>With documents</summary>
+
+```python
+from transformers import AutoTokenizer
+
+tokenizer = AutoTokenizer.from_pretrained("SmallDoge/Doge2-tokenizer")
+
+documents = [
+    {
+        "title": "Cheems's case",
+        "text": "Cheems is a 233-year-old alchemist, but he is very kidney deficient."
+    },
+]
+
+conversation = [
+    {"role": "system", "content": "You are a helpful assistant."},
+    {"role": "user", "content": "What's wrong with Cheems? What treatment does he need?"},
+    {"role": "assistant", "content": "Based on Cheems' symptoms, I recommend the following treatment: For Cheems with severe kidney deficiency, it is recommended to eat more leeks and oysters."},
+]
+
+inputs = tokenizer.apply_chat_template(
+    documents=documents,
+    conversation=conversation,
+    tokenize=False,
+)
+print(inputs)
+```
+```shell
+<|im_start|>system
+You are a helpful assistant.
+
+You have access to the following documents. Please use them to answer the user's question.
+
+Title: Cheems's case
+Content: Cheems is a 233-year-old alchemist, but he is very kidney deficient.
+
+If the documents don't contain relevant information, rely on your general knowledge but acknowledge when you're doing so.<|im_end|>
+<|im_start|>user
+What's wrong with Cheems? What treatment does he need?<|im_end|>
+<|im_start|>assistant
+<think>
+
+</think>
+
+Based on Cheems' symptoms, I recommend the following treatment: For Cheems with severe kidney deficiency, it is recommended to eat more leeks and oysters.<|im_end|>
+```
+</details>
+
+<details>
+<summary>With tools</summary>
+
+```python
+from transformers import AutoTokenizer
+
+tokenizer = AutoTokenizer.from_pretrained("SmallDoge/Doge2-tokenizer")
+
+tools = [
+    {
+        "name": "recommend_treatment",
+        "description": "Treatment is recommended based on patient symptoms and diagnosis.",
+        "arguments": {
+            "type": "object",
+            "properties": {
+                "diagnosis": {
+                    "type": "string",
+                    "description": "Patient diagnostic results"
+                },
+                "severity": {
+                    "type": "string",
+                    "enum": ["mild", "moderate", "severe"],
+                    "description": "Severity of the condition, can be mild, moderate, or severe."
+                }
+            },
+            "required": ["diagnosis", "severity"]
+        }
+    }
+]
+
+conversation = [
+    {"role": "system", "content": "You are a helpful assistant."},
+    {"role": "user", "content": "What's wrong with Cheems? What treatment does he need?"},
+    {"role": "assistant", "content": "<tool_call>\n{\"name\": \"recommend_treatment\", \"arguments\": {\"diagnosis\": \"Deficiency of kidney\", \"severity\": \"severe\"}}\n</tool_call>"},
+    {"role": "tool", "content": "For Cheems with severe kidney deficiency, it is recommended to eat more leeks and oysters."},
+    {"role": "assistant", "content": "Based on Cheems' symptoms, I recommend the following treatment: For Cheems with severe kidney deficiency, it is recommended to eat more leeks and oysters."},
+]
+
+inputs = tokenizer.apply_chat_template(
+    tools=tools,
+    conversation=conversation,
+    tokenize=False,
+)
+print(inputs)
+```
+```shell
+<|im_start|>system
+You are a helpful assistant.
+
+You may call one or more functions to assist with the user query. You are provided with function signatures within <tools></tools> XML tags:
+
+<tools>
+{"name": "recommend_treatment", "description": "Treatment is recommended based on patient symptoms and diagnosis.", "arguments": {"type": "object", "properties": {"diagnosis": {"type": "string", "description": "Patient diagnostic results"}, "severity": {"type": "string", "enum": ["mild", "moderate", "severe"], "description": "Severity of the condition, can be mild, moderate, or severe."}}, "required": ["diagnosis", "severity"]}}
+</tools>
+
+For each function call, return a json object with function name and arguments within <tool_call></tool_call> XML tags:
+
+<tool_call>
+{"name": <function-name>, "arguments": <args-json-object>}
+</tool_call><|im_end|>
+<|im_start|>user
+What's wrong with Cheems? What treatment does he need?<|im_end|>
+<|im_start|>assistant
+<tool_call>
+{"name": "recommend_treatment", "arguments": {"diagnosis": "Deficiency of kidney", "severity": "severe"}}
+</tool_call><|im_end|>
+<|im_start|>user
+<tool_response>
+For Cheems with severe kidney deficiency, it is recommended to eat more leeks and oysters.
+</tool_response><|im_end|>
+<|im_start|>assistant
+<think>
+
+</think>
+
+Based on Cheems' symptoms, I recommend the following treatment: For Cheems with severe kidney deficiency, it is recommended to eat more leeks and oysters.<|im_end|>
+```
+</details>
+
+<details>
+<summary>With reasoning</summary>
+
+```python
+from transformers import AutoTokenizer
+
+tokenizer = AutoTokenizer.from_pretrained("SmallDoge/Doge2-tokenizer")
+
+conversation = [
+    {"role": "system", "content": "You are a helpful assistant."},
+    {"role": "user", "content": "What's wrong with Cheems? What treatment does he need?"},
+    {"role": "assistant", "reasoning_content": "Cheems is a dog, a old dog. He is been around for a long time, so his innards are not as good as before. If he is not careful, he will get kidney deficiency. He needs to eat more leeks and oysters.", "content": "Based on Cheems' symptoms, I recommend the following treatment: For Cheems with severe kidney deficiency, it is recommended to eat more leeks and oysters."},
+]
+
+inputs = tokenizer.apply_chat_template(
+    conversation=conversation,
+    tokenize=False,
+)
+print(inputs)
+```
+```shell
+<|im_start|>system
+You are a helpful assistant.<|im_end|>
+<|im_start|>user
+What's wrong with Cheems? What treatment does he need?<|im_end|>
+<|im_start|>assistant
+<think>
+Cheems is a dog, a old dog. He is been around for a long time, so his innards are not as good as before. If he is not careful, he will get kidney deficiency. He needs to eat more leeks and oysters.
+</think>
+
+Based on Cheems' symptoms, I recommend the following treatment: For Cheems with severe kidney deficiency, it is recommended to eat more leeks and oysters.<|im_end|>
+```
+</details>
+
+<details>
+<summary>With documents tools reasoning</summary>
+
+```python
+from transformers import AutoTokenizer
+
+tokenizer = AutoTokenizer.from_pretrained("SmallDoge/Doge2-tokenizer")
+
+documents = [
+    {
+        "title": "Cheems's case",
+        "text": "Cheems is a 233-year-old alchemist, but he is very kidney deficient."
+    },
+]
+
+tools = [
+    {
+        "name": "recommend_treatment",
+        "description": "Treatment is recommended based on patient symptoms and diagnosis.",
+        "arguments": {
+            "type": "object",
+            "properties": {
+                "diagnosis": {
+                    "type": "string",
+                    "description": "Patient diagnostic results"
+                },
+                "severity": {
+                    "type": "string",
+                    "enum": ["mild", "moderate", "severe"],
+                    "description": "Severity of the condition, can be mild, moderate, or severe."
+                }
+            },
+            "required": ["diagnosis", "severity"]
+        }
+    }
+]
+
+conversation = [
+    {"role": "system", "content": "You are a helpful assistant."},
+    {"role": "user", "content": "What's wrong with Cheems? What treatment does he need?"},
+    {"role": "assistant", "content": "<tool_call>\n{\"name\": \"recommend_treatment\", \"arguments\": {\"diagnosis\": \"Deficiency of kidney\", \"severity\": \"severe\"}}\n</tool_call>"},
+    {"role": "tool", "content": "For Cheems with severe kidney deficiency, it is recommended to eat more leeks and oysters."},
+    {"role": "assistant", "reasoning_content": "Cheems is a dog, a old dog. He is been around for a long time, so his innards are not as good as before. If he is not careful, he will get kidney deficiency. He needs to eat more leeks and oysters.", "content": "Based on Cheems' symptoms, I recommend the following treatment: For Cheems with severe kidney deficiency, it is recommended to eat more leeks and oysters."},
+]
+
+inputs = tokenizer.apply_chat_template(
+    documents=documents,
+    tools=tools,
+    conversation=conversation,
+    tokenize=False,
+)
+print(inputs)
+```
+```shell
+<|im_start|>system
+You are a helpful assistant.
+
+You have access to the following documents. Please use them to answer the user's question.
+
+Title: Cheems's case
+Content: Cheems is a 233-year-old alchemist, but he is very kidney deficient.
+
+If the documents don't contain relevant information, rely on your general knowledge but acknowledge when you're doing so.
+
+You may call one or more functions to assist with the user query. You are provided with function signatures within <tools></tools> XML tags:
+
+<tools>
+{"name": "recommend_treatment", "description": "Treatment is recommended based on patient symptoms and diagnosis.", "arguments": {"type": "object", "properties": {"diagnosis": {"type": "string", "description": "Patient diagnostic results"}, "severity": {"type": "string", "enum": ["mild", "moderate", "severe"], "description": "Severity of the condition, can be mild, moderate, or severe."}}, "required": ["diagnosis", "severity"]}}
+</tools>
+
+For each function call, return a json object with function name and arguments within <tool_call></tool_call> XML tags:
+
+<tool_call>
+{"name": <function-name>, "arguments": <args-json-object>}
+</tool_call><|im_end|>
+<|im_start|>user
+What's wrong with Cheems? What treatment does he need?<|im_end|>
+<|im_start|>assistant
+<tool_call>
+{"name": "recommend_treatment", "arguments": {"diagnosis": "Deficiency of kidney", "severity": "severe"}}
+</tool_call><|im_end|>
+<|im_start|>user
+<tool_response>
+For Cheems with severe kidney deficiency, it is recommended to eat more leeks and oysters.
+</tool_response><|im_end|>
+<|im_start|>assistant
+<think>
+Cheems is a dog, a old dog. He is been around for a long time, so his innards are not as good as before. If he is not careful, he will get kidney deficiency. He needs to eat more leeks and oysters.
+</think>
+
+Based on Cheems' symptoms, I recommend the following treatment: For Cheems with severe kidney deficiency, it is recommended to eat more leeks and oysters.<|im_end|>
+```
+</details>

--- a/docs/models.md
+++ b/docs/models.md
@@ -1,0 +1,116 @@
+# Model Documentation
+
+## 🏗️ Architecture Overview
+
+SmallDoge models feature innovative architectural components designed for efficiency and performance:
+
+### Core Innovations
+
+1. **Dynamic Mask Attention (DMA)** - Efficient attention mechanism for long sequences
+2. **Cross Domain Mixture of Experts (CDMoE)** - Sparse experts with dense-to-sparse continuation training  
+3. **WSD Scheduler** - Warmup-Stable-Decay for seamless checkpoint resumption
+
+<div align="center">
+    <img src="../assets/doge_architecture.png" alt="Doge Architecture" width="80%"/>
+</div>
+
+## 📊 Available Models
+
+### 🔧 Base Models
+
+Pre-trained foundation models for general-purpose language understanding:
+
+| Model | Parameters | Speed (i7-11 CPU) | MMLU | HuggingFace |
+|-------|------------|------------------|------|-------------|
+| **Doge-20M** | 20M | 142 tok/s | 25.4 | [🤗 View Card](./Doge-20M.md) |
+| **Doge-60M** | 60M | 62 tok/s | 26.4 | [🤗 View Card](./Doge-60M.md) |
+| **Doge-160M** | 160M | 28 tok/s | 29.2 | [🤗 View Card](./Doge-160M.md) |
+| **Doge-320M** | 320M | 16 tok/s | 33.8 | [🤗 View Card](./Doge-320M.md) |
+
+### 💬 Instruction Models  
+
+Chat-optimized models fine-tuned for conversations and instruction following:
+
+| Model | Base Model | Training | HuggingFace |
+|-------|------------|----------|-------------|
+| **Doge-20M-Instruct** | Doge-20M | SFT + DPO | [🤗 View Card](./Doge-20M-Instruct.md) |
+| **Doge-60M-Instruct** | Doge-60M | SFT + DPO | [🤗 View Card](./Doge-60M-Instruct.md) |
+| **Doge-160M-Instruct** | Doge-160M | SFT + DPO | [🤗 View Card](./Doge-160M-Instruct.md) |
+| **Doge-320M-Instruct** | Doge-320M | SFT + DPO | [🤗 View Card](./Doge-320M-Instruct.md) |
+
+### 🎯 Intermediate Training Models
+
+Partially trained models for supervised fine-tuning stages:
+
+| Model | Training Stage | Base Model | HuggingFace |
+|-------|----------------|------------|-------------|
+| **Doge-20M-Instruct-SFT** | SFT Only | Doge-20M | [🤗 View Card](./Doge-20M-Instruct-SFT.md) |
+| **Doge-60M-Instruct-SFT** | SFT Only | Doge-60M | [🤗 View Card](./Doge-60M-Instruct-SFT.md) |
+| **Doge-160M-Instruct-SFT** | SFT Only | Doge-160M | [🤗 View Card](./Doge-160M-Instruct-SFT.md) |
+| **Doge-320M-Instruct-SFT** | SFT Only | Doge-320M | [🤗 View Card](./Doge-320M-Instruct-SFT.md) |
+
+### 🔄 Checkpoint Models
+
+Intermediate checkpoints for continued training with stable learning rates:
+
+| Model | Recommended LR | Scheduler | HuggingFace |
+|-------|----------------|-----------|-------------|
+| **Doge-20M-checkpoint** | 8e-3 | wsd_scheduler | [🤗 View Card](./Doge-20M-checkpoint.md) |
+| **Doge-60M-checkpoint** | 6e-3 | wsd_scheduler | [🤗 View Card](./Doge-60M-checkpoint.md) |
+| **Doge-160M-checkpoint** | 4e-3 | wsd_scheduler | [🤗 View Card](./Doge-160M-checkpoint.md) |
+| **Doge-320M-checkpoint** | 2e-3 | wsd_scheduler | [🤗 View Card](./Doge-320M-checkpoint.md) |
+
+### 🧠 Reasoning Models
+
+Advanced models enhanced with reasoning capabilities through knowledge distillation:
+
+| Model | Training Method | Capabilities | HuggingFace |
+|-------|-----------------|--------------|-------------|
+| **Doge-160M-Reason-Distill** | Knowledge Distillation + GRPO | Chain-of-thought reasoning | [🤗 View Card](./Doge-160M-Reason-Distill.md) |
+
+
+## ⚡ Quick Start
+
+### Basic Usage
+
+```python
+from transformers import AutoTokenizer, AutoModelForCausalLM
+
+# Load any model (example: instruction model)
+model_name = "SmallDoge/Doge-60M-Instruct"
+tokenizer = AutoTokenizer.from_pretrained(model_name, trust_remote_code=True)
+model = AutoModelForCausalLM.from_pretrained(model_name, trust_remote_code=True)
+
+# Generate text
+prompt = "Explain machine learning in simple terms:"
+inputs = tokenizer(prompt, return_tensors="pt")
+outputs = model.generate(**inputs, max_length=200, temperature=0.7)
+print(tokenizer.decode(outputs[0], skip_special_tokens=True))
+```
+
+For detailed usage examples, see individual model cards above.
+
+## 🎯 Model Selection Guide
+
+### Choose by Use Case
+
+- **🔬 Research & Experimentation**: Start with Doge-20M for fast iteration
+- **💻 Development & Prototyping**: Use Doge-60M for balanced performance  
+- **🎯 Production Applications**: Deploy Doge-160M or Doge-320M for best quality
+- **💬 Chat Applications**: Use `-Instruct` variants for conversation
+- **🧠 Reasoning Tasks**: Try Doge-160M-Reason-Distill for complex problems
+- **📚 Continued Training**: Use `-checkpoint` models with specified learning rates
+
+### Choose by Resources
+
+- **CPU-only**: Doge-20M (142 tok/s) or Doge-60M (62 tok/s)
+- **Mobile/Edge**: Doge-20M with quantization
+- **GPU Available**: Any model, Doge-320M recommended for best results
+- **Memory Constrained**: Doge-20M (0.5GB) or Doge-60M (1.2GB)
+
+## 📚 Documentation
+
+- **[Training Guide](./training.md)** - Complete training pipeline
+- **[Quick Start](./quickstart.md)** - Get started in 5 minutes
+- **[Installation](./installation.md)** - Setup instructions
+- **[WebUI Guide](./webui.md)** - Web interface usage


### PR DESCRIPTION
This pull request introduces documentation for several models in the SmallDoge family, detailing their training processes, configurations, and evaluation metrics. The changes include comprehensive guides for different variants of the Doge-160M model, focusing on their unique features and intended uses.

### Documentation for Model Variants:

#### Doge 160M Instruct SFT:
* Added documentation for the `Doge-160M-Instruct-SFT` model, which uses Dynamic Mask Attention and was trained on the `SmolTalk` dataset. Includes usage examples, training details, and environment specifications.

#### Doge 160M Instruct:
* Added documentation for the `Doge-160M-Instruct` model, which combines SFT on `SmolTalk` and DPO on `UltraFeedback Binarized`. Includes evaluation metrics, training procedures, and environment details.

#### Doge 160M Reason Distill:
* Added documentation for the `Doge-160M-Reason-Distill` model, which was trained on the `Reason-Distill` dataset. Introduced a systematic reasoning framework for question-answering tasks and provided training details.

#### Doge 160M:
* Added documentation for the base `Doge-160M` model, focusing on pre-training on the `Smollm-Corpus` dataset. Includes evaluation metrics, pre-training details, and links to checkpoints for further training.