### PR TITLE
Change dataset packing strategy to wrapped

### DIFF
--- a/src/small_doge/processor/pt_datasets_process.py
+++ b/src/small_doge/processor/pt_datasets_process.py
@@ -142,7 +142,7 @@ def prepare_dataset(
         if isinstance(dataset, Dataset):  # `IterableDataset.map` does not support `desc`
             map_kwargs["desc"] = f"Packing {dataset_name} dataset"
         dataset = dataset.select_columns("input_ids")
-        dataset = pack_dataset(dataset, seq_length=max_length, strategy="ffd", map_kwargs=map_kwargs)
+        dataset = pack_dataset(dataset, seq_length=max_length, strategy="wrapped", map_kwargs=map_kwargs)
     elif max_length is not None:
         if isinstance(dataset, Dataset):  # `IterableDataset.map` does not support `desc`
             map_kwargs["desc"] = f"Truncating {dataset_name} dataset"

--- a/src/small_doge/processor/sft_datasets_process.py
+++ b/src/small_doge/processor/sft_datasets_process.py
@@ -168,7 +168,7 @@ def prepare_dataset(
         if isinstance(dataset, Dataset):  # `IterableDataset.map` does not support `desc`
             map_kwargs["desc"] = f"Packing {dataset_name} dataset"
         dataset = dataset.select_columns("input_ids")
-        dataset = pack_dataset(dataset, max_length, map_kwargs)
+        dataset = pack_dataset(dataset, seq_length=max_length, strategy="wrapped", map_kwargs=map_kwargs)
     elif max_length is not None:
         if isinstance(dataset, Dataset):  # `IterableDataset.map` does not support `desc`
             map_kwargs["desc"] = f"Truncating {dataset_name} dataset"


### PR DESCRIPTION
Switch the dataset packing algorithm to a wrapped strategy for improved memory efficiency and clarity. Explicit parameters for sequence length and strategy enhance code readability and consistency.