### PR TITLE
Adds Doge-1.6B-MoE stage 1 training configuration

### DIFF
--- a/recipes/doge/Doge-1.6B-MoE/config_stage1.yaml
+++ b/recipes/doge/Doge-1.6B-MoE/config_stage1.yaml
@@ -1,0 +1,82 @@
+# Logging and Output arguments
+log_level: info
+logging_strategy: steps
+logging_steps: 1
+report_to:
+- wandb
+save_strategy: steps
+save_steps: 100
+output_dir: data/Doge-1.6B-MoE-Stage1
+overwrite_output_dir: true
+push_to_hub: true
+private: true
+token: <your-token>
+hub_model_id: Doge-1.6B-MoE-Stage1
+hub_strategy: every_save
+
+# Model arguments
+model_config:
+  vocab_size: 128256
+  hidden_size: 1024
+  intermediate_size: 4096
+  num_hidden_layers: 32
+  hidden_dropout: 0.0
+  hidden_act: "silu"
+  use_cache: True
+  tie_word_embeddings: True
+  keep_window_size: 4096
+  max_position_embeddings: 4096
+  rope_theta: 40000.0
+  num_attention_heads: 8
+  num_key_value_heads: 4
+  is_moe: True
+  num_experts: 16384
+  num_experts_per_tok: 32
+  output_router_logits: True
+  _attn_implementation_internal: sdpa
+  bos_token_id: 128000
+  eos_token_id: 128001
+  pad_token_id: 128001
+
+model_name_or_path: SmallDoge/Doge-tokenizer
+torch_dtype: bfloat16
+
+# Data training arguments
+datasets_and_ratios:
+  - "<dataset_name_or_path>": 1.0
+total_sample_size: 128000000
+dataset_text_field: "text"
+max_length: 4096
+packing: false
+dataset_num_proc: 4
+cache_dir: "./cache"
+
+# PT trainer arguments
+preprocessing_num_workers: 8 # Equal to the number of GPUs you are using
+seed: 233
+do_train: True
+max_steps: 250000
+per_device_train_batch_size: 1
+do_eval: False
+eval_strategy: 'no'
+eval_steps: 100
+per_device_eval_batch_size: 1
+optim: adamw_torch_fused
+adam_beta1: 0.9
+adam_beta2: 0.95
+adam_epsilon: 1.0e-8
+learning_rate: 2.0e-3
+lr_scheduler_type: warmup_stable_decay
+lr_scheduler_kwargs:
+  warmup_type: linear
+  decay_type: linear
+  num_decay_steps: 0
+  min_lr_ratio: 0.0
+warmup_steps: 2000
+weight_decay: 0.01
+gradient_accumulation_steps: 64
+gradient_checkpointing: true
+gradient_checkpointing_kwargs:
+  use_reentrant: false
+max_grad_norm: 1.0
+bf16: True


### PR DESCRIPTION
Establishes comprehensive training setup for a 1.6B parameter Mixture of Experts model with 16,384 experts and 32 experts per token.

Configures model architecture with 32 hidden layers, 1024 hidden size, and 4096 context length using SiLU activation and grouped query attention.

Sets up training pipeline with AdamW optimizer, linear warmup schedule, and gradient checkpointing for memory efficiency during 250k training steps.

Enables Weights & Biases logging and automatic model uploads to Hugging Face Hub for experiment tracking and model versioning.