### PR TITLE
Add SFT configurations for Doge-40M-MoE and Doge-180M-MoE models

### DIFF
--- a/recipes/doge/Doge-180M-MoE-Instruct/sft/config_full.yaml
+++ b/recipes/doge/Doge-180M-MoE-Instruct/sft/config_full.yaml
@@ -1,0 +1,56 @@
+# Logging and Output arguments
+log_level: info
+logging_strategy: steps
+logging_steps: 1
+report_to:
+- wandb
+- tensorboard
+save_strategy: steps
+save_steps: 100
+output_dir: data/Doge-180M-MoE-Instruct-SFT
+overwrite_output_dir: true
+push_to_hub: true
+private: true
+token: <your-token>
+hub_model_id: Doge-180M-MoE-Instruct-SFT
+hub_strategy: every_save
+
+# Model arguments
+model_name_or_path: SmallDoge/Doge-180M-MoE
+model_revision: main
+trust_remote_code: True
+torch_dtype: bfloat16
+
+# Data training arguments
+datasets_and_ratios:
+  - "<dataset_name_or_path>": 1.0
+total_sample_size: -1  # Set to -1 to keep all samples
+dataset_text_field: "text"
+max_length: 2048
+packing: false
+dataset_num_proc: 4
+cache_dir: "./cache"
+
+# SFT trainer arguments
+preprocessing_num_workers: 1 # Equal to the number of GPUs you are using
+seed: 233
+do_train: True
+num_train_epochs: 2
+per_device_train_batch_size: 1
+do_eval: False
+eval_strategy: 'no'
+eval_steps: 1000
+per_device_eval_batch_size: 1
+optim: adamw_torch
+learning_rate: 6.0e-4
+lr_scheduler_type: cosine_with_min_lr
+lr_scheduler_kwargs:
+  min_lr_rate: 0.1
+warmup_ratio: 0.1
+weight_decay: 0.01
+gradient_accumulation_steps: 128
+gradient_checkpointing: false
+gradient_checkpointing_kwargs:
+  use_reentrant: false
+max_grad_norm: 1.0
+bf16: True

--- a/recipes/doge/Doge-40M-MoE-Instruct/sft/config_full.yaml
+++ b/recipes/doge/Doge-40M-MoE-Instruct/sft/config_full.yaml
@@ -1,0 +1,56 @@
+# Logging and Output arguments
+log_level: info
+logging_strategy: steps
+logging_steps: 1
+report_to:
+- wandb
+- tensorboard
+save_strategy: steps
+save_steps: 100
+output_dir: data/Doge-40M-MoE-Instruct-SFT
+overwrite_output_dir: true
+push_to_hub: true
+private: true
+token: <your-token>
+hub_model_id: Doge-40M-MoE-Instruct-SFT
+hub_strategy: every_save
+
+# Model arguments
+model_name_or_path: SmallDoge/Doge-40M-MoE
+model_revision: main
+trust_remote_code: True
+torch_dtype: bfloat16
+
+# Data training arguments
+datasets_and_ratios:
+  - "<dataset_name_or_path>": 1.0
+total_sample_size: -1  # Set to -1 to keep all samples
+dataset_text_field: "text"
+max_length: 2048
+packing: false
+dataset_num_proc: 4
+cache_dir: "./cache"
+
+# SFT trainer arguments
+preprocessing_num_workers: 1 # Equal to the number of GPUs you are using
+seed: 233
+do_train: True
+num_train_epochs: 2
+per_device_train_batch_size: 1
+do_eval: False
+eval_strategy: 'no'
+eval_steps: 1000
+per_device_eval_batch_size: 1
+optim: adamw_torch
+learning_rate: 8.0e-4
+lr_scheduler_type: cosine_with_min_lr
+lr_scheduler_kwargs:
+  min_lr_rate: 0.1
+warmup_ratio: 0.1
+weight_decay: 0.01
+gradient_accumulation_steps: 128
+gradient_checkpointing: false
+gradient_checkpointing_kwargs:
+  use_reentrant: false
+max_grad_norm: 1.0
+bf16: True


### PR DESCRIPTION
Introduce comprehensive supervised fine-tuning setups for both models, including logging to wandb and tensorboard, optimized training parameters, and model pushing to the hub.