### PR TITLE
Remove unused ConstantLengthDataset references and simplify dataset preparation

### DIFF
--- a/src/small_doge/processor/pt_datasets_process.py
+++ b/src/small_doge/processor/pt_datasets_process.py
@@ -20,7 +20,6 @@ import re
 from datasets import Dataset, IterableDataset, DatasetDict, load_dataset, load_from_disk, concatenate_datasets
 from transformers import AutoTokenizer, PreTrainedTokenizerBase
 from trl.data_utils import pack_dataset, truncate_dataset
-from trl.trainer.utils import ConstantLengthDataset
 from argparse import ArgumentParser
 
 


### PR DESCRIPTION
Eliminate unnecessary checks and imports related to ConstantLengthDataset, streamlining the dataset preparation process and improving code maintainability.